### PR TITLE
Remove advanced settings

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -23,7 +23,6 @@ Artie Deployment resource
 
 ### Optional
 
-- `advanced_settings` (Attributes) (see [below for nested schema](#nestedatt--advanced_settings))
 - `destination_uuid` (String)
 - `status` (String)
 
@@ -95,7 +94,6 @@ Required:
 
 Optional:
 
-- `advanced_settings` (Attributes) (see [below for nested schema](#nestedatt--source--tables--advanced_settings))
 - `enable_history_mode` (Boolean)
 - `individual_deployment` (Boolean)
 - `is_partitioned` (Boolean)
@@ -103,38 +101,3 @@ Optional:
 Read-Only:
 
 - `uuid` (String)
-
-<a id="nestedatt--source--tables--advanced_settings"></a>
-### Nested Schema for `source.tables.advanced_settings`
-
-Optional:
-
-- `alias` (String)
-- `autoscale_max_replicas` (Number)
-- `autoscale_target_value` (Number)
-- `buffer_rows` (Number)
-- `flush_interval_seconds` (Number)
-- `flush_size_kb` (Number)
-- `k8s_request_cpu` (Number)
-- `k8s_request_memory_mb` (Number)
-- `skip_delete` (Boolean)
-
-
-
-
-<a id="nestedatt--advanced_settings"></a>
-### Nested Schema for `advanced_settings`
-
-Optional:
-
-- `buffer_rows` (Number)
-- `drop_deleted_columns` (Boolean)
-- `enable_heartbeats` (Boolean)
-- `enable_soft_delete` (Boolean)
-- `flush_interval_seconds` (Number)
-- `flush_size_kb` (Number)
-- `include_artie_updated_at_column` (Boolean)
-- `include_database_updated_at_column` (Boolean)
-- `publication_auto_create_mode` (String)
-- `publication_name_override` (String)
-- `replication_slot_override` (String)

--- a/examples/deployments/main.tf
+++ b/examples/deployments/main.tf
@@ -10,126 +10,115 @@ provider "artie" {
   endpoint = "http://0.0.0.0:8000"
 }
 
-import {
-  to = artie_destination.snowflake
-  id = "51b180a0-fbb9-49a2-ab45-cb46d913416d"
-}
-
-import {
-  to = artie_deployment.dev_postgres_to_snowflake
-  id = "c3dfa503-b6ae-48f3-a6b1-8491a506126d"
-}
-
-variable "snowflake_password" {
-  type      = string
-  sensitive = true
-}
-variable "postgres_password" {
-  type      = string
-  sensitive = true
-}
-
-resource "artie_destination" "snowflake" {
-  name  = "Snowflake"
-  label = "Snowflake (Partner Account)"
-  config = {
-    snowflake_account_url = "https://znb46775.snowflakecomputing.com"
-    username              = "tang8330"
-    password              = var.snowflake_password
-    snowflake_virtual_dwh = "compute_wh"
-  }
-}
-
-resource "artie_deployment" "dev_postgres_to_snowflake" {
-  name = "Dev PostgreSQL > Snowflake"
-  source = {
-    name = "PostgreSQL"
-    config = {
-      host     = "db-postgresql-sfo3-03243-do-user-13261354-0.c.db.ondigitalocean.com"
-      port     = 25060
-      database = "prod_dump_july_2024_4cvzb"
-      user     = "doadmin"
-      password = var.postgres_password
-    }
-    tables = [
-      {
-        name   = "invite"
-        schema = "public"
-      }
-    ]
-  }
-  destination_uuid = artie_destination.snowflake.uuid
-  destination_config = {
-    database = "DEV_TEST"
-    schema   = "PUBLIC"
-  }
-  # advanced_settings = {
-  #   enable_soft_delete = true
-  # }
-}
+# import {
+#   to = artie_destination.snowflake
+#   id = "51b180a0-fbb9-49a2-ab45-cb46d913416d"
+# }
 
 # import {
-#   to = artie_destination.bigquery
-#   id = "fa7d4efc-3957-41e5-b29c-66e2d49bffde"
+#   to = artie_deployment.dev_postgres_to_snowflake
+#   id = "c3dfa503-b6ae-48f3-a6b1-8491a506126d"
 # }
 
-# variable "mongodb_password" {
+# variable "snowflake_password" {
+#   type      = string
+#   sensitive = true
+# }
+# variable "postgres_password" {
 #   type      = string
 #   sensitive = true
 # }
 
-# variable "gcp_creds" {
-#   type      = string
-#   sensitive = true
-# }
-
-# resource "artie_destination" "bigquery" {
-#   name  = "BigQuery"
-#   label = "BigQuery"
+# resource "artie_destination" "snowflake" {
+#   name  = "Snowflake"
+#   label = "Snowflake (Partner Account)"
 #   config = {
-#     gcp_location         = "us"
-#     gcp_project_id       = "artie-labs"
-#     gcp_credentials_data = var.gcp_creds
+#     snowflake_account_url = "https://znb46775.snowflakecomputing.com"
+#     username              = "tang8330"
+#     password              = var.snowflake_password
+#     snowflake_virtual_dwh = "compute_wh"
 #   }
 # }
 
-# import {
-#   to = artie_deployment.example
-#   id = "38d5d2db-870a-4a38-a76c-9891b0e5122d"
-# }
-
-# resource "artie_deployment" "example" {
-#   name = "MongoDB ➡️ BigQuery"
+# resource "artie_deployment" "dev_postgres_to_snowflake" {
+#   name = "Dev PostgreSQL > Snowflake"
 #   source = {
-#     name = "MongoDB"
+#     name = "PostgreSQL"
 #     config = {
-#       database = "myFirstDatabase"
-#       host     = "mongodb+srv://cluster0.szddg49.mongodb.net/"
-#       port     = 0
-#       user     = "artie"
-#       password = var.mongodb_password
+#       host     = "db-postgresql-sfo3-03243-do-user-13261354-0.c.db.ondigitalocean.com"
+#       port     = 25060
+#       database = "prod_dump_july_2024_4cvzb"
+#       user     = "doadmin"
+#       password = var.postgres_password
 #     }
 #     tables = [
 #       {
-#         name   = "customers"
-#         schema = ""
-#         advanced_settings = {
-#           skip_delete = false
-#         }
-#       },
-#       {
-#         name              = "stock"
-#         schema            = ""
-#         advanced_settings = {}
+#         name   = "invite"
+#         schema = "public"
 #       }
 #     ]
 #   }
-#   destination_uuid = artie_destination.bigquery.uuid
+#   destination_uuid = artie_destination.snowflake.uuid
 #   destination_config = {
-#     dataset = "customers"
-#   }
-#   advanced_settings = {
-#     enable_soft_delete     = true
-#     flush_interval_seconds = 60
+#     database = "DEV_TEST"
+#     schema   = "PUBLIC"
 #   }
 # }
+
+import {
+  to = artie_destination.bigquery
+  id = "fa7d4efc-3957-41e5-b29c-66e2d49bffde"
+}
+
+variable "mongodb_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "gcp_creds" {
+  type      = string
+  sensitive = true
+}
+
+resource "artie_destination" "bigquery" {
+  name  = "BigQuery"
+  label = "BigQuery"
+  config = {
+    gcp_location         = "us"
+    gcp_project_id       = "artie-labs"
+    gcp_credentials_data = var.gcp_creds
+  }
+}
+
+import {
+  to = artie_deployment.example
+  id = "38d5d2db-870a-4a38-a76c-9891b0e5122d"
+}
+
+resource "artie_deployment" "example" {
+  name = "MongoDB ➡️ BigQuery"
+  source = {
+    name = "MongoDB"
+    config = {
+      database = "myFirstDatabase"
+      host     = "mongodb+srv://cluster0.szddg49.mongodb.net/"
+      port     = 0
+      user     = "artie"
+      password = var.mongodb_password
+    }
+    tables = [
+      {
+        name   = "customers"
+        schema = ""
+      },
+      {
+        name   = "stock"
+        schema = ""
+      }
+    ]
+  }
+  destination_uuid = artie_destination.bigquery.uuid
+  destination_config = {
+    dataset = "customers"
+  }
+}

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -86,46 +85,10 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 								"enable_history_mode":   schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
 								"individual_deployment": schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
 								"is_partitioned":        schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
-								"advanced_settings": schema.SingleNestedAttribute{
-									Optional: true,
-									Computed: true,
-									Attributes: map[string]schema.Attribute{
-										"alias":                  schema.StringAttribute{Optional: true, Computed: true, Default: stringdefault.StaticString(""), PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-										"skip_delete":            schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
-										"flush_interval_seconds": schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-										"buffer_rows":            schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-										"flush_size_kb":          schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-										"autoscale_max_replicas": schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-										"autoscale_target_value": schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-										"k8s_request_cpu":        schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-										"k8s_request_memory_mb":  schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-										// TODO BigQueryPartitionSettings, MergePredicates, ExcludeColumns
-									},
-									PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
-								},
 							},
 						},
 					},
 				},
-			},
-			"advanced_settings": schema.SingleNestedAttribute{
-				Optional: true,
-				Computed: true,
-				Attributes: map[string]schema.Attribute{
-					"drop_deleted_columns":               schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
-					"include_artie_updated_at_column":    schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(true), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
-					"include_database_updated_at_column": schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
-					"enable_heartbeats":                  schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
-					"enable_soft_delete":                 schema.BoolAttribute{Optional: true, Computed: true, Default: booldefault.StaticBool(false), PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}},
-					"flush_interval_seconds":             schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-					"buffer_rows":                        schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-					"flush_size_kb":                      schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
-					"publication_name_override":          schema.StringAttribute{Optional: true, Computed: true, Default: stringdefault.StaticString(""), PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-					"replication_slot_override":          schema.StringAttribute{Optional: true, Computed: true, Default: stringdefault.StaticString(""), PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-					"publication_auto_create_mode":       schema.StringAttribute{Optional: true, Computed: true, Default: stringdefault.StaticString(""), PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-					// TODO PartitionRegex
-				},
-				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 			"destination_config": schema.SingleNestedAttribute{
 				Required: true,
@@ -212,15 +175,6 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	model.UUID = deployment.UUID
 	model.CompanyUUID = deployment.CompanyUUID
 	model.Status = deployment.Status
-	if model.AdvancedSettings.FlushIntervalSeconds == 0 {
-		model.AdvancedSettings.FlushIntervalSeconds = deployment.AdvancedSettings.FlushIntervalSeconds
-	}
-	if model.AdvancedSettings.BufferRows == 0 {
-		model.AdvancedSettings.BufferRows = deployment.AdvancedSettings.BufferRows
-	}
-	if model.AdvancedSettings.FlushSizeKB == 0 {
-		model.AdvancedSettings.FlushSizeKB = deployment.AdvancedSettings.FlushSizeKB
-	}
 
 	// Second API request: update the newly created deployment
 	payload := map[string]any{

--- a/internal/provider/models/deployment_api_model.go
+++ b/internal/provider/models/deployment_api_model.go
@@ -5,14 +5,13 @@ type DeploymentAPIResponse struct {
 }
 
 type DeploymentAPIModel struct {
-	UUID              string                              `json:"uuid"`
-	CompanyUUID       string                              `json:"companyUUID"`
-	Name              string                              `json:"name"`
-	Status            string                              `json:"status"`
-	DestinationUUID   string                              `json:"destinationUUID"`
-	Source            SourceAPIModel                      `json:"source"`
-	AdvancedSettings  *DeploymentAdvancedSettingsAPIModel `json:"advancedSettings"`
-	DestinationConfig DestinationConfigAPIModel           `json:"uniqueConfig"`
+	UUID              string                    `json:"uuid"`
+	CompanyUUID       string                    `json:"companyUUID"`
+	Name              string                    `json:"name"`
+	Status            string                    `json:"status"`
+	DestinationUUID   string                    `json:"destinationUUID"`
+	Source            SourceAPIModel            `json:"source"`
+	DestinationConfig DestinationConfigAPIModel `json:"uniqueConfig"`
 }
 
 type SourceAPIModel struct {
@@ -40,41 +39,12 @@ type DynamoDBConfigAPIModel struct {
 }
 
 type TableAPIModel struct {
-	UUID                 string                         `json:"uuid"`
-	Name                 string                         `json:"name"`
-	Schema               string                         `json:"schema"`
-	EnableHistoryMode    bool                           `json:"enableHistoryMode"`
-	IndividualDeployment bool                           `json:"individualDeployment"`
-	IsPartitioned        bool                           `json:"isPartitioned"`
-	AdvancedSettings     *TableAdvancedSettingsAPIModel `json:"advancedSettings"`
-}
-
-type TableAdvancedSettingsAPIModel struct {
-	Alias                string `json:"alias"`
-	SkipDelete           bool   `json:"skipDelete"`
-	FlushIntervalSeconds int64  `json:"flushIntervalSeconds"`
-	BufferRows           int64  `json:"bufferRows"`
-	FlushSizeKB          int64  `json:"flushSizeKb"`
-	AutoscaleMaxReplicas int64  `json:"autoscaleMaxReplicas"`
-	AutoscaleTargetValue int64  `json:"autoscaleTargetValue"`
-	K8sRequestCPU        int64  `json:"k8sRequestCPU"`
-	K8sRequestMemoryMB   int64  `json:"k8sRequestMemoryMB"`
-	// TODO BigQueryPartitionSettings, MergePredicates, ExcludeColumns
-}
-
-type DeploymentAdvancedSettingsAPIModel struct {
-	DropDeletedColumns             bool   `json:"dropDeletedColumns"`
-	IncludeArtieUpdatedAtColumn    bool   `json:"includeArtieUpdatedAtColumn"`
-	IncludeDatabaseUpdatedAtColumn bool   `json:"includeDatabaseUpdatedAtColumn"`
-	EnableHeartbeats               bool   `json:"enableHeartbeats"`
-	EnableSoftDelete               bool   `json:"enableSoftDelete"`
-	FlushIntervalSeconds           int64  `json:"flushIntervalSeconds"`
-	BufferRows                     int64  `json:"bufferRows"`
-	FlushSizeKB                    int64  `json:"flushSizeKb"`
-	PublicationNameOverride        string `json:"publicationNameOverride"`
-	ReplicationSlotOverride        string `json:"replicationSlotOverride"`
-	PublicationAutoCreateMode      string `json:"publicationAutoCreateMode"`
-	// TODO PartitionRegex
+	UUID                 string `json:"uuid"`
+	Name                 string `json:"name"`
+	Schema               string `json:"schema"`
+	EnableHistoryMode    bool   `json:"enableHistoryMode"`
+	IndividualDeployment bool   `json:"individualDeployment"`
+	IsPartitioned        bool   `json:"isPartitioned"`
 }
 
 type DestinationConfigAPIModel struct {

--- a/internal/provider/models/deployment_resource_model.go
+++ b/internal/provider/models/deployment_resource_model.go
@@ -9,7 +9,6 @@ type DeploymentResourceModel struct {
 	Status            types.String                      `tfsdk:"status"`
 	DestinationUUID   types.String                      `tfsdk:"destination_uuid"`
 	Source            *SourceModel                      `tfsdk:"source"`
-	AdvancedSettings  *DeploymentAdvancedSettingsModel  `tfsdk:"advanced_settings"`
 	DestinationConfig *DeploymentDestinationConfigModel `tfsdk:"destination_config"`
 }
 
@@ -38,41 +37,12 @@ type DynamoDBConfigModel struct {
 }
 
 type TableModel struct {
-	UUID                 types.String                `tfsdk:"uuid"`
-	Name                 types.String                `tfsdk:"name"`
-	Schema               types.String                `tfsdk:"schema"`
-	EnableHistoryMode    types.Bool                  `tfsdk:"enable_history_mode"`
-	IndividualDeployment types.Bool                  `tfsdk:"individual_deployment"`
-	IsPartitioned        types.Bool                  `tfsdk:"is_partitioned"`
-	AdvancedSettings     *TableAdvancedSettingsModel `tfsdk:"advanced_settings"`
-}
-
-type TableAdvancedSettingsModel struct {
-	Alias                types.String `tfsdk:"alias"`
-	SkipDelete           types.Bool   `tfsdk:"skip_delete"`
-	FlushIntervalSeconds types.Int64  `tfsdk:"flush_interval_seconds"`
-	BufferRows           types.Int64  `tfsdk:"buffer_rows"`
-	FlushSizeKB          types.Int64  `tfsdk:"flush_size_kb"`
-	AutoscaleMaxReplicas types.Int64  `tfsdk:"autoscale_max_replicas"`
-	AutoscaleTargetValue types.Int64  `tfsdk:"autoscale_target_value"`
-	K8sRequestCPU        types.Int64  `tfsdk:"k8s_request_cpu"`
-	K8sRequestMemoryMB   types.Int64  `tfsdk:"k8s_request_memory_mb"`
-	// TODO BigQueryPartitionSettings, MergePredicates, ExcludeColumns
-}
-
-type DeploymentAdvancedSettingsModel struct {
-	DropDeletedColumns             types.Bool   `tfsdk:"drop_deleted_columns"`
-	IncludeArtieUpdatedAtColumn    types.Bool   `tfsdk:"include_artie_updated_at_column"`
-	IncludeDatabaseUpdatedAtColumn types.Bool   `tfsdk:"include_database_updated_at_column"`
-	EnableHeartbeats               types.Bool   `tfsdk:"enable_heartbeats"`
-	EnableSoftDelete               types.Bool   `tfsdk:"enable_soft_delete"`
-	FlushIntervalSeconds           types.Int64  `tfsdk:"flush_interval_seconds"`
-	BufferRows                     types.Int64  `tfsdk:"buffer_rows"`
-	FlushSizeKB                    types.Int64  `tfsdk:"flush_size_kb"`
-	PublicationNameOverride        types.String `tfsdk:"publication_name_override"`
-	ReplicationSlotOverride        types.String `tfsdk:"replication_slot_override"`
-	PublicationAutoCreateMode      types.String `tfsdk:"publication_auto_create_mode"`
-	// TODO PartitionRegex
+	UUID                 types.String `tfsdk:"uuid"`
+	Name                 types.String `tfsdk:"name"`
+	Schema               types.String `tfsdk:"schema"`
+	EnableHistoryMode    types.Bool   `tfsdk:"enable_history_mode"`
+	IndividualDeployment types.Bool   `tfsdk:"individual_deployment"`
+	IsPartitioned        types.Bool   `tfsdk:"is_partitioned"`
 }
 
 type DeploymentDestinationConfigModel struct {

--- a/internal/provider/models/translate_deployment.go
+++ b/internal/provider/models/translate_deployment.go
@@ -14,21 +14,6 @@ func DeploymentAPIToResourceModel(apiModel DeploymentAPIModel, resourceModel *De
 
 	tables := []TableModel{}
 	for _, apiTable := range apiModel.Source.Tables {
-		var advSettings *TableAdvancedSettingsModel
-		if apiTable.AdvancedSettings != nil {
-			advSettings = &TableAdvancedSettingsModel{
-				Alias:                types.StringValue(apiTable.AdvancedSettings.Alias),
-				SkipDelete:           types.BoolValue(apiTable.AdvancedSettings.SkipDelete),
-				FlushIntervalSeconds: types.Int64Value(apiTable.AdvancedSettings.FlushIntervalSeconds),
-				BufferRows:           types.Int64Value(apiTable.AdvancedSettings.BufferRows),
-				FlushSizeKB:          types.Int64Value(apiTable.AdvancedSettings.FlushSizeKB),
-				AutoscaleMaxReplicas: types.Int64Value(apiTable.AdvancedSettings.AutoscaleMaxReplicas),
-				AutoscaleTargetValue: types.Int64Value(apiTable.AdvancedSettings.AutoscaleTargetValue),
-				K8sRequestCPU:        types.Int64Value(apiTable.AdvancedSettings.K8sRequestCPU),
-				K8sRequestMemoryMB:   types.Int64Value(apiTable.AdvancedSettings.K8sRequestMemoryMB),
-				// TODO BigQueryPartitionSettings, MergePredicates, ExcludeColumns
-			}
-		}
 		tables = append(tables, TableModel{
 			UUID:                 types.StringValue(apiTable.UUID),
 			Name:                 types.StringValue(apiTable.Name),
@@ -36,7 +21,6 @@ func DeploymentAPIToResourceModel(apiModel DeploymentAPIModel, resourceModel *De
 			EnableHistoryMode:    types.BoolValue(apiTable.EnableHistoryMode),
 			IndividualDeployment: types.BoolValue(apiTable.IndividualDeployment),
 			IsPartitioned:        types.BoolValue(apiTable.IsPartitioned),
-			AdvancedSettings:     advSettings,
 		})
 	}
 	var dynamoDBConfig *DynamoDBConfigModel
@@ -72,25 +56,6 @@ func DeploymentAPIToResourceModel(apiModel DeploymentAPIModel, resourceModel *De
 		BucketName:            types.StringValue(apiModel.DestinationConfig.BucketName),
 		OptionalPrefix:        types.StringValue(apiModel.DestinationConfig.OptionalPrefix),
 	}
-
-	var advSettings *DeploymentAdvancedSettingsModel
-	if apiModel.AdvancedSettings != nil {
-		advSettings = &DeploymentAdvancedSettingsModel{
-			DropDeletedColumns:             types.BoolValue(apiModel.AdvancedSettings.DropDeletedColumns),
-			IncludeArtieUpdatedAtColumn:    types.BoolValue(apiModel.AdvancedSettings.IncludeArtieUpdatedAtColumn),
-			IncludeDatabaseUpdatedAtColumn: types.BoolValue(apiModel.AdvancedSettings.IncludeDatabaseUpdatedAtColumn),
-			EnableHeartbeats:               types.BoolValue(apiModel.AdvancedSettings.EnableHeartbeats),
-			EnableSoftDelete:               types.BoolValue(apiModel.AdvancedSettings.EnableSoftDelete),
-			FlushIntervalSeconds:           types.Int64Value(apiModel.AdvancedSettings.FlushIntervalSeconds),
-			BufferRows:                     types.Int64Value(apiModel.AdvancedSettings.BufferRows),
-			FlushSizeKB:                    types.Int64Value(apiModel.AdvancedSettings.FlushSizeKB),
-			PublicationNameOverride:        types.StringValue(apiModel.AdvancedSettings.PublicationNameOverride),
-			ReplicationSlotOverride:        types.StringValue(apiModel.AdvancedSettings.ReplicationSlotOverride),
-			PublicationAutoCreateMode:      types.StringValue(apiModel.AdvancedSettings.PublicationAutoCreateMode),
-			// TODO PartitionRegex
-		}
-	}
-	resourceModel.AdvancedSettings = advSettings
 }
 
 func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) DeploymentAPIModel {
@@ -100,21 +65,6 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) Deploym
 		if tableUUID == "" {
 			tableUUID = uuid.Nil.String()
 		}
-		var advSettings *TableAdvancedSettingsAPIModel
-		if table.AdvancedSettings != nil {
-			advSettings = &TableAdvancedSettingsAPIModel{
-				Alias:                table.AdvancedSettings.Alias.ValueString(),
-				SkipDelete:           table.AdvancedSettings.SkipDelete.ValueBool(),
-				FlushIntervalSeconds: table.AdvancedSettings.FlushIntervalSeconds.ValueInt64(),
-				BufferRows:           table.AdvancedSettings.BufferRows.ValueInt64(),
-				FlushSizeKB:          table.AdvancedSettings.FlushSizeKB.ValueInt64(),
-				AutoscaleMaxReplicas: table.AdvancedSettings.AutoscaleMaxReplicas.ValueInt64(),
-				AutoscaleTargetValue: table.AdvancedSettings.AutoscaleTargetValue.ValueInt64(),
-				K8sRequestCPU:        table.AdvancedSettings.K8sRequestCPU.ValueInt64(),
-				K8sRequestMemoryMB:   table.AdvancedSettings.K8sRequestMemoryMB.ValueInt64(),
-				// TODO BigQueryPartitionSettings, MergePredicates, ExcludeColumns
-			}
-		}
 		tables = append(tables, TableAPIModel{
 			UUID:                 tableUUID,
 			Name:                 table.Name.ValueString(),
@@ -122,7 +72,6 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) Deploym
 			EnableHistoryMode:    table.EnableHistoryMode.ValueBool(),
 			IndividualDeployment: table.IndividualDeployment.ValueBool(),
 			IsPartitioned:        table.IsPartitioned.ValueBool(),
-			AdvancedSettings:     advSettings,
 		})
 	}
 
@@ -134,24 +83,6 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) Deploym
 			StreamsArn:         resourceModel.Source.Config.DynamoDB.StreamsArn.ValueString(),
 			AwsAccessKeyID:     resourceModel.Source.Config.DynamoDB.AwsAccessKeyID.ValueString(),
 			AwsSecretAccessKey: resourceModel.Source.Config.DynamoDB.AwsSecretAccessKey.ValueString(),
-		}
-	}
-
-	var advSettings *DeploymentAdvancedSettingsAPIModel
-	if resourceModel.AdvancedSettings != nil {
-		advSettings = &DeploymentAdvancedSettingsAPIModel{
-			DropDeletedColumns:             resourceModel.AdvancedSettings.DropDeletedColumns.ValueBool(),
-			IncludeArtieUpdatedAtColumn:    resourceModel.AdvancedSettings.IncludeArtieUpdatedAtColumn.ValueBool(),
-			IncludeDatabaseUpdatedAtColumn: resourceModel.AdvancedSettings.IncludeDatabaseUpdatedAtColumn.ValueBool(),
-			EnableHeartbeats:               resourceModel.AdvancedSettings.EnableHeartbeats.ValueBool(),
-			EnableSoftDelete:               resourceModel.AdvancedSettings.EnableSoftDelete.ValueBool(),
-			FlushIntervalSeconds:           resourceModel.AdvancedSettings.FlushIntervalSeconds.ValueInt64(),
-			BufferRows:                     resourceModel.AdvancedSettings.BufferRows.ValueInt64(),
-			FlushSizeKB:                    resourceModel.AdvancedSettings.FlushSizeKB.ValueInt64(),
-			PublicationNameOverride:        resourceModel.AdvancedSettings.PublicationNameOverride.ValueString(),
-			ReplicationSlotOverride:        resourceModel.AdvancedSettings.ReplicationSlotOverride.ValueString(),
-			PublicationAutoCreateMode:      resourceModel.AdvancedSettings.PublicationAutoCreateMode.ValueString(),
-			// TODO PartitionRegex
 		}
 	}
 
@@ -184,6 +115,5 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) Deploym
 			BucketName:            resourceModel.DestinationConfig.BucketName.ValueString(),
 			OptionalPrefix:        resourceModel.DestinationConfig.OptionalPrefix.ValueString(),
 		},
-		AdvancedSettings: advSettings,
 	}
 }


### PR DESCRIPTION
We decided to simplify things for v1 by not exposing advanced settings. Some of these are things we eventually want to abstract away from users (e.g. flush interval) and some are very rarely used and make more sense to set up via the UI (e.g. partition regex). If/when we do need to expose some of the advanced settings to be managed by terraform, we should then add only the necessary ones and make them top-level properties on the deployment/table.