### PR TITLE
Ping destination to test connection before updating

### DIFF
--- a/internal/artieclient/destination.go
+++ b/internal/artieclient/destination.go
@@ -2,6 +2,7 @@ package artieclient
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -65,6 +66,30 @@ func (dc DestinationClient) Update(ctx context.Context, destination Destination)
 	}
 
 	return makeRequest[Destination](ctx, dc.client, http.MethodPost, path, destination)
+}
+
+func (dc DestinationClient) TestConnection(ctx context.Context, destination Destination) error {
+	path, err := url.JoinPath(dc.basePath(), "ping")
+	if err != nil {
+		return err
+	}
+
+	body := map[string]any{
+		"type":          destination.Type,
+		"sharedConfig":  destination.Config,
+		"sshTunnelUUID": destination.SSHTunnelUUID,
+	}
+
+	response, err := makeRequest[validationResponse](ctx, dc.client, http.MethodPost, path, body)
+	if err != nil {
+		return err
+	}
+
+	if response.Error != "" {
+		return fmt.Errorf("failed to connect to destination: %s", response.Error)
+	}
+
+	return nil
 }
 
 func (dc DestinationClient) Delete(ctx context.Context, destinationUUID string) error {

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -159,7 +159,13 @@ func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	destination, err := r.client.Destinations().Update(ctx, models.DestinationResourceToAPIModel(data))
+	destination := models.DestinationResourceToAPIModel(data)
+	if err := r.client.Destinations().TestConnection(ctx, destination); err != nil {
+		resp.Diagnostics.AddError("Unable to connect to Destination", err.Error())
+		return
+	}
+
+	destination, err := r.client.Destinations().Update(ctx, destination)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update Destination", err.Error())
 		return

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -161,7 +161,7 @@ func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateReq
 
 	destination := models.DestinationResourceToAPIModel(data)
 	if err := r.client.Destinations().TestConnection(ctx, destination); err != nil {
-		resp.Diagnostics.AddError("Unable to connect to Destination", err.Error())
+		resp.Diagnostics.AddError("Unable to Update Destination", err.Error())
 		return
 	}
 


### PR DESCRIPTION
When I change the snowflake username to be incorrect, the ping fails with a helpful error message and the destination doesn't get updated:
![Screenshot 2024-08-20 at 1 32 55 PM](https://github.com/user-attachments/assets/fcaa5b16-1b36-4f63-a55f-d9687fa262b3)

When all the settings are correct, the ping succeeds and the update succeeds:
![Screenshot 2024-08-20 at 1 35 13 PM](https://github.com/user-attachments/assets/2d154088-4eb3-486d-9d60-8902d3f725dc)

