### PR TITLE
Validate before creating a new deployment

### DIFF
--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Deployment struct {
-	UUID                     uuid.UUID         `json:"uuid"`
+	UUID                     *uuid.UUID        `json:"uuid"`
 	Name                     string            `json:"name"`
 	Status                   string            `json:"status"`
 	Source                   Source            `json:"source"`

--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -56,6 +56,14 @@ type DestinationConfig struct {
 	SchemaNamePrefix      string `json:"schemaNamePrefix"`
 }
 
+func (bd BaseDeployment) ToFullDeployment(_uuid uuid.UUID, status string) Deployment {
+	return Deployment{
+		UUID:           _uuid,
+		Status:         status,
+		BaseDeployment: bd,
+	}
+}
+
 type DeploymentClient struct {
 	client Client
 }

--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -11,7 +11,6 @@ import (
 
 type BaseDeployment struct {
 	Name                     string            `json:"name"`
-	Status                   string            `json:"status"`
 	Source                   Source            `json:"source"`
 	DestinationUUID          *uuid.UUID        `json:"destinationUUID"`
 	DestinationConfig        DestinationConfig `json:"uniqueConfig"`
@@ -21,7 +20,8 @@ type BaseDeployment struct {
 
 type Deployment struct {
 	BaseDeployment
-	UUID uuid.UUID `json:"uuid"`
+	UUID   uuid.UUID `json:"uuid"`
+	Status string    `json:"status"`
 }
 
 type Source struct {

--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -9,8 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
-type Deployment struct {
-	UUID                     *uuid.UUID        `json:"uuid"`
+type BaseDeployment struct {
 	Name                     string            `json:"name"`
 	Status                   string            `json:"status"`
 	Source                   Source            `json:"source"`
@@ -18,6 +17,11 @@ type Deployment struct {
 	DestinationConfig        DestinationConfig `json:"uniqueConfig"`
 	SSHTunnelUUID            *uuid.UUID        `json:"sshTunnelUUID"`
 	SnowflakeEcoScheduleUUID *uuid.UUID        `json:"snowflakeEcoScheduleUUID"`
+}
+
+type Deployment struct {
+	BaseDeployment
+	UUID uuid.UUID `json:"uuid"`
 }
 
 type Source struct {
@@ -86,10 +90,6 @@ func (dc DeploymentClient) Create(ctx context.Context, sourceType string) (Deplo
 }
 
 func (dc DeploymentClient) Update(ctx context.Context, deployment Deployment) (Deployment, error) {
-	if deployment.UUID == nil {
-		return Deployment{}, fmt.Errorf("deployment UUID is required")
-	}
-
 	path, err := url.JoinPath(dc.basePath(), deployment.UUID.String())
 	if err != nil {
 		return Deployment{}, err
@@ -108,7 +108,7 @@ func (dc DeploymentClient) Update(ctx context.Context, deployment Deployment) (D
 	return response.Deployment, nil
 }
 
-func (dc DeploymentClient) ValidateSource(ctx context.Context, deployment Deployment) error {
+func (dc DeploymentClient) ValidateSource(ctx context.Context, deployment BaseDeployment) error {
 	path, err := url.JoinPath(dc.basePath(), "validate-source")
 	if err != nil {
 		return err
@@ -132,7 +132,7 @@ func (dc DeploymentClient) ValidateSource(ctx context.Context, deployment Deploy
 	return nil
 }
 
-func (dc DeploymentClient) ValidateDestination(ctx context.Context, deployment Deployment) error {
+func (dc DeploymentClient) ValidateDestination(ctx context.Context, deployment BaseDeployment) error {
 	path, err := url.JoinPath(dc.basePath(), "validate-destination")
 	if err != nil {
 		return err

--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -86,6 +86,10 @@ func (dc DeploymentClient) Create(ctx context.Context, sourceType string) (Deplo
 }
 
 func (dc DeploymentClient) Update(ctx context.Context, deployment Deployment) (Deployment, error) {
+	if deployment.UUID == nil {
+		return Deployment{}, fmt.Errorf("deployment UUID is required")
+	}
+
 	path, err := url.JoinPath(dc.basePath(), deployment.UUID.String())
 	if err != nil {
 		return Deployment{}, err

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -190,7 +190,7 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Validate config before creating the deployment
-	deployment := data.ToBaseAPIModel()
+	deployment := data.ToAPIBaseModel()
 	if err := r.client.Deployments().ValidateSource(ctx, deployment); err != nil {
 		resp.Diagnostics.AddError("Unable to Create Deployment", err.Error())
 		return
@@ -251,7 +251,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	baseDeployment := data.ToBaseAPIModel()
+	baseDeployment := data.ToAPIBaseModel()
 	if err := r.client.Deployments().ValidateSource(ctx, baseDeployment); err != nil {
 		resp.Diagnostics.AddError("Unable to Update Deployment", err.Error())
 		return

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -264,14 +264,14 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	fullDeployment := models.DeploymentResourceToAPIModel(data)
-	fullDeployment, err := r.client.Deployments().Update(ctx, fullDeployment)
+	updatedDeployment, err := r.client.Deployments().Update(ctx, fullDeployment)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update Deployment", err.Error())
 		return
 	}
 
 	// Translate API response into Terraform state & save state
-	models.DeploymentAPIToResourceModel(fullDeployment, &data)
+	models.DeploymentAPIToResourceModel(updatedDeployment, &data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -210,7 +210,7 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Fill in computed fields from the API response of the newly created deployment
-	fullDeployment := models.BaseDeploymentAPIModelToDeploymentAPIModel(deployment, createdDeployment.UUID)
+	fullDeployment := models.BaseDeploymentAPIModelToDeploymentAPIModel(deployment, createdDeployment.UUID, createdDeployment.Status)
 	fullDeployment.Status = createdDeployment.Status
 
 	// Second API request: update the newly created deployment
@@ -263,15 +263,15 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	deployment := models.DeploymentResourceToAPIModel(data)
-	deployment, err := r.client.Deployments().Update(ctx, deployment)
+	fullDeployment := models.DeploymentResourceToAPIModel(data)
+	fullDeployment, err := r.client.Deployments().Update(ctx, fullDeployment)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update Deployment", err.Error())
 		return
 	}
 
 	// Translate API response into Terraform state & save state
-	models.DeploymentAPIToResourceModel(deployment, &data)
+	models.DeploymentAPIToResourceModel(fullDeployment, &data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -190,7 +190,7 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Validate config before creating the deployment
-	deployment := models.DeploymentResourceToBaseAPIModel(data)
+	deployment := data.ToBaseAPIModel()
 	if err := r.client.Deployments().ValidateSource(ctx, deployment); err != nil {
 		resp.Diagnostics.AddError("Unable to Create Deployment", err.Error())
 		return
@@ -210,8 +210,7 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Fill in computed fields from the API response of the newly created deployment
-	fullDeployment := models.BaseDeploymentAPIModelToDeploymentAPIModel(deployment, createdDeployment.UUID, createdDeployment.Status)
-	fullDeployment.Status = createdDeployment.Status
+	fullDeployment := deployment.ToFullDeployment(createdDeployment.UUID, createdDeployment.Status)
 
 	// Second API request: update the newly created deployment
 	updatedDeployment, err := r.client.Deployments().Update(ctx, fullDeployment)
@@ -252,7 +251,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	baseDeployment := models.DeploymentResourceToBaseAPIModel(data)
+	baseDeployment := data.ToBaseAPIModel()
 	if err := r.client.Deployments().ValidateSource(ctx, baseDeployment); err != nil {
 		resp.Diagnostics.AddError("Unable to Update Deployment", err.Error())
 		return
@@ -263,7 +262,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	fullDeployment := models.DeploymentResourceToAPIModel(data)
+	fullDeployment := data.ToAPIModel()
 	updatedDeployment, err := r.client.Deployments().Update(ctx, fullDeployment)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update Deployment", err.Error())

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -203,7 +203,7 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Our API's create endpoint only accepts the source type, so we need to send two requests:
 	// one to create the bare-bones deployment, then one to update it with the rest of the data
-	createdDeployment, err := r.client.Deployments().Create(ctx, data.Source.Type.ValueString())
+	createdDeployment, err := r.client.Deployments().Create(ctx, deployment.Source.Type)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Create Deployment", err.Error())
 		return
@@ -262,8 +262,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	fullDeployment := data.ToAPIModel()
-	updatedDeployment, err := r.client.Deployments().Update(ctx, fullDeployment)
+	updatedDeployment, err := r.client.Deployments().Update(ctx, data.ToAPIModel())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update Deployment", err.Error())
 		return

--- a/internal/provider/models/translate_deployment.go
+++ b/internal/provider/models/translate_deployment.go
@@ -64,9 +64,9 @@ func DeploymentAPIToResourceModel(apiModel artieclient.Deployment, resourceModel
 	}
 }
 
-func DeploymentResourceToBaseAPIModel(resourceModel DeploymentResourceModel) artieclient.BaseDeployment {
+func (rm DeploymentResourceModel) ToBaseAPIModel() artieclient.BaseDeployment {
 	tables := []artieclient.Table{}
-	for _, table := range resourceModel.Source.Tables {
+	for _, table := range rm.Source.Tables {
 		tableUUID := table.UUID.ValueString()
 		if tableUUID == "" {
 			tableUUID = uuid.Nil.String()
@@ -82,56 +82,48 @@ func DeploymentResourceToBaseAPIModel(resourceModel DeploymentResourceModel) art
 	}
 
 	baseDeployment := artieclient.BaseDeployment{
-		Name:            resourceModel.Name.ValueString(),
-		DestinationUUID: ParseOptionalUUID(resourceModel.DestinationUUID),
+		Name:            rm.Name.ValueString(),
+		DestinationUUID: ParseOptionalUUID(rm.DestinationUUID),
 		Source: artieclient.Source{
-			Type:   resourceModel.Source.Type.ValueString(),
+			Type:   rm.Source.Type.ValueString(),
 			Tables: tables,
 		},
 		DestinationConfig: artieclient.DestinationConfig{
-			Dataset:               resourceModel.DestinationConfig.Dataset.ValueString(),
-			Database:              resourceModel.DestinationConfig.Database.ValueString(),
-			Schema:                resourceModel.DestinationConfig.Schema.ValueString(),
-			UseSameSchemaAsSource: resourceModel.DestinationConfig.UseSameSchemaAsSource.ValueBool(),
-			SchemaNamePrefix:      resourceModel.DestinationConfig.SchemaNamePrefix.ValueString(),
+			Dataset:               rm.DestinationConfig.Dataset.ValueString(),
+			Database:              rm.DestinationConfig.Database.ValueString(),
+			Schema:                rm.DestinationConfig.Schema.ValueString(),
+			UseSameSchemaAsSource: rm.DestinationConfig.UseSameSchemaAsSource.ValueBool(),
+			SchemaNamePrefix:      rm.DestinationConfig.SchemaNamePrefix.ValueString(),
 		},
-		SSHTunnelUUID:            ParseOptionalUUID(resourceModel.SSHTunnelUUID),
-		SnowflakeEcoScheduleUUID: ParseOptionalUUID(resourceModel.SnowflakeEcoScheduleUUID),
+		SSHTunnelUUID:            ParseOptionalUUID(rm.SSHTunnelUUID),
+		SnowflakeEcoScheduleUUID: ParseOptionalUUID(rm.SnowflakeEcoScheduleUUID),
 	}
 
-	switch resourceModel.Source.Type.ValueString() {
+	switch rm.Source.Type.ValueString() {
 	case string(PostgreSQL):
 		baseDeployment.Source.Config = artieclient.SourceConfig{
-			Host:     resourceModel.Source.PostgresConfig.Host.ValueString(),
-			Port:     resourceModel.Source.PostgresConfig.Port.ValueInt32(),
-			User:     resourceModel.Source.PostgresConfig.User.ValueString(),
-			Password: resourceModel.Source.PostgresConfig.Password.ValueString(),
-			Database: resourceModel.Source.PostgresConfig.Database.ValueString(),
+			Host:     rm.Source.PostgresConfig.Host.ValueString(),
+			Port:     rm.Source.PostgresConfig.Port.ValueInt32(),
+			User:     rm.Source.PostgresConfig.User.ValueString(),
+			Password: rm.Source.PostgresConfig.Password.ValueString(),
+			Database: rm.Source.PostgresConfig.Database.ValueString(),
 		}
 	case string(MySQL):
 		baseDeployment.Source.Config = artieclient.SourceConfig{
-			Host:     resourceModel.Source.MySQLConfig.Host.ValueString(),
-			Port:     resourceModel.Source.MySQLConfig.Port.ValueInt32(),
-			User:     resourceModel.Source.MySQLConfig.User.ValueString(),
-			Password: resourceModel.Source.MySQLConfig.Password.ValueString(),
-			Database: resourceModel.Source.MySQLConfig.Database.ValueString(),
+			Host:     rm.Source.MySQLConfig.Host.ValueString(),
+			Port:     rm.Source.MySQLConfig.Port.ValueInt32(),
+			User:     rm.Source.MySQLConfig.User.ValueString(),
+			Password: rm.Source.MySQLConfig.Password.ValueString(),
+			Database: rm.Source.MySQLConfig.Database.ValueString(),
 		}
 	}
 
 	return baseDeployment
 }
 
-func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artieclient.Deployment {
+func (rm DeploymentResourceModel) ToAPIModel() artieclient.Deployment {
 	return artieclient.Deployment{
-		UUID:           parseUUID(resourceModel.UUID),
-		BaseDeployment: DeploymentResourceToBaseAPIModel(resourceModel),
-	}
-}
-
-func BaseDeploymentAPIModelToDeploymentAPIModel(baseDeployment artieclient.BaseDeployment, _uuid uuid.UUID, status string) artieclient.Deployment {
-	return artieclient.Deployment{
-		UUID:           _uuid,
-		Status:         status,
-		BaseDeployment: baseDeployment,
+		UUID:           parseUUID(rm.UUID),
+		BaseDeployment: rm.ToBaseAPIModel(),
 	}
 }

--- a/internal/provider/models/translate_deployment.go
+++ b/internal/provider/models/translate_deployment.go
@@ -64,7 +64,7 @@ func DeploymentAPIToResourceModel(apiModel artieclient.Deployment, resourceModel
 	}
 }
 
-func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artieclient.Deployment {
+func DeploymentResourceToBaseAPIModel(resourceModel DeploymentResourceModel) artieclient.BaseDeployment {
 	tables := []artieclient.Table{}
 	for _, table := range resourceModel.Source.Tables {
 		tableUUID := table.UUID.ValueString()
@@ -81,8 +81,7 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artiecl
 		})
 	}
 
-	apiModel := artieclient.Deployment{
-		UUID:            ParseOptionalUUID(resourceModel.UUID),
+	baseDeployment := artieclient.BaseDeployment{
 		Name:            resourceModel.Name.ValueString(),
 		Status:          resourceModel.Status.ValueString(),
 		DestinationUUID: ParseOptionalUUID(resourceModel.DestinationUUID),
@@ -103,7 +102,7 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artiecl
 
 	switch resourceModel.Source.Type.ValueString() {
 	case string(PostgreSQL):
-		apiModel.Source.Config = artieclient.SourceConfig{
+		baseDeployment.Source.Config = artieclient.SourceConfig{
 			Host:     resourceModel.Source.PostgresConfig.Host.ValueString(),
 			Port:     resourceModel.Source.PostgresConfig.Port.ValueInt32(),
 			User:     resourceModel.Source.PostgresConfig.User.ValueString(),
@@ -111,7 +110,7 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artiecl
 			Database: resourceModel.Source.PostgresConfig.Database.ValueString(),
 		}
 	case string(MySQL):
-		apiModel.Source.Config = artieclient.SourceConfig{
+		baseDeployment.Source.Config = artieclient.SourceConfig{
 			Host:     resourceModel.Source.MySQLConfig.Host.ValueString(),
 			Port:     resourceModel.Source.MySQLConfig.Port.ValueInt32(),
 			User:     resourceModel.Source.MySQLConfig.User.ValueString(),
@@ -120,5 +119,19 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artiecl
 		}
 	}
 
-	return apiModel
+	return baseDeployment
+}
+
+func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artieclient.Deployment {
+	return artieclient.Deployment{
+		UUID:           parseUUID(resourceModel.UUID),
+		BaseDeployment: DeploymentResourceToBaseAPIModel(resourceModel),
+	}
+}
+
+func BaseDeploymentAPIModelToDeploymentAPIModel(baseDeployment artieclient.BaseDeployment, deploymentUUID uuid.UUID) artieclient.Deployment {
+	return artieclient.Deployment{
+		UUID:           deploymentUUID,
+		BaseDeployment: baseDeployment,
+	}
 }

--- a/internal/provider/models/translate_deployment.go
+++ b/internal/provider/models/translate_deployment.go
@@ -83,7 +83,6 @@ func DeploymentResourceToBaseAPIModel(resourceModel DeploymentResourceModel) art
 
 	baseDeployment := artieclient.BaseDeployment{
 		Name:            resourceModel.Name.ValueString(),
-		Status:          resourceModel.Status.ValueString(),
 		DestinationUUID: ParseOptionalUUID(resourceModel.DestinationUUID),
 		Source: artieclient.Source{
 			Type:   resourceModel.Source.Type.ValueString(),
@@ -129,9 +128,10 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artiecl
 	}
 }
 
-func BaseDeploymentAPIModelToDeploymentAPIModel(baseDeployment artieclient.BaseDeployment, deploymentUUID uuid.UUID) artieclient.Deployment {
+func BaseDeploymentAPIModelToDeploymentAPIModel(baseDeployment artieclient.BaseDeployment, _uuid uuid.UUID, status string) artieclient.Deployment {
 	return artieclient.Deployment{
-		UUID:           deploymentUUID,
+		UUID:           _uuid,
+		Status:         status,
 		BaseDeployment: baseDeployment,
 	}
 }

--- a/internal/provider/models/translate_deployment.go
+++ b/internal/provider/models/translate_deployment.go
@@ -64,9 +64,9 @@ func DeploymentAPIToResourceModel(apiModel artieclient.Deployment, resourceModel
 	}
 }
 
-func (rm DeploymentResourceModel) ToBaseAPIModel() artieclient.BaseDeployment {
+func (d DeploymentResourceModel) ToBaseAPIModel() artieclient.BaseDeployment {
 	tables := []artieclient.Table{}
-	for _, table := range rm.Source.Tables {
+	for _, table := range d.Source.Tables {
 		tableUUID := table.UUID.ValueString()
 		if tableUUID == "" {
 			tableUUID = uuid.Nil.String()
@@ -82,48 +82,48 @@ func (rm DeploymentResourceModel) ToBaseAPIModel() artieclient.BaseDeployment {
 	}
 
 	baseDeployment := artieclient.BaseDeployment{
-		Name:            rm.Name.ValueString(),
-		DestinationUUID: ParseOptionalUUID(rm.DestinationUUID),
+		Name:            d.Name.ValueString(),
+		DestinationUUID: ParseOptionalUUID(d.DestinationUUID),
 		Source: artieclient.Source{
-			Type:   rm.Source.Type.ValueString(),
+			Type:   d.Source.Type.ValueString(),
 			Tables: tables,
 		},
 		DestinationConfig: artieclient.DestinationConfig{
-			Dataset:               rm.DestinationConfig.Dataset.ValueString(),
-			Database:              rm.DestinationConfig.Database.ValueString(),
-			Schema:                rm.DestinationConfig.Schema.ValueString(),
-			UseSameSchemaAsSource: rm.DestinationConfig.UseSameSchemaAsSource.ValueBool(),
-			SchemaNamePrefix:      rm.DestinationConfig.SchemaNamePrefix.ValueString(),
+			Dataset:               d.DestinationConfig.Dataset.ValueString(),
+			Database:              d.DestinationConfig.Database.ValueString(),
+			Schema:                d.DestinationConfig.Schema.ValueString(),
+			UseSameSchemaAsSource: d.DestinationConfig.UseSameSchemaAsSource.ValueBool(),
+			SchemaNamePrefix:      d.DestinationConfig.SchemaNamePrefix.ValueString(),
 		},
-		SSHTunnelUUID:            ParseOptionalUUID(rm.SSHTunnelUUID),
-		SnowflakeEcoScheduleUUID: ParseOptionalUUID(rm.SnowflakeEcoScheduleUUID),
+		SSHTunnelUUID:            ParseOptionalUUID(d.SSHTunnelUUID),
+		SnowflakeEcoScheduleUUID: ParseOptionalUUID(d.SnowflakeEcoScheduleUUID),
 	}
 
-	switch rm.Source.Type.ValueString() {
+	switch d.Source.Type.ValueString() {
 	case string(PostgreSQL):
 		baseDeployment.Source.Config = artieclient.SourceConfig{
-			Host:     rm.Source.PostgresConfig.Host.ValueString(),
-			Port:     rm.Source.PostgresConfig.Port.ValueInt32(),
-			User:     rm.Source.PostgresConfig.User.ValueString(),
-			Password: rm.Source.PostgresConfig.Password.ValueString(),
-			Database: rm.Source.PostgresConfig.Database.ValueString(),
+			Host:     d.Source.PostgresConfig.Host.ValueString(),
+			Port:     d.Source.PostgresConfig.Port.ValueInt32(),
+			User:     d.Source.PostgresConfig.User.ValueString(),
+			Password: d.Source.PostgresConfig.Password.ValueString(),
+			Database: d.Source.PostgresConfig.Database.ValueString(),
 		}
 	case string(MySQL):
 		baseDeployment.Source.Config = artieclient.SourceConfig{
-			Host:     rm.Source.MySQLConfig.Host.ValueString(),
-			Port:     rm.Source.MySQLConfig.Port.ValueInt32(),
-			User:     rm.Source.MySQLConfig.User.ValueString(),
-			Password: rm.Source.MySQLConfig.Password.ValueString(),
-			Database: rm.Source.MySQLConfig.Database.ValueString(),
+			Host:     d.Source.MySQLConfig.Host.ValueString(),
+			Port:     d.Source.MySQLConfig.Port.ValueInt32(),
+			User:     d.Source.MySQLConfig.User.ValueString(),
+			Password: d.Source.MySQLConfig.Password.ValueString(),
+			Database: d.Source.MySQLConfig.Database.ValueString(),
 		}
 	}
 
 	return baseDeployment
 }
 
-func (rm DeploymentResourceModel) ToAPIModel() artieclient.Deployment {
+func (d DeploymentResourceModel) ToAPIModel() artieclient.Deployment {
 	return artieclient.Deployment{
-		UUID:           parseUUID(rm.UUID),
-		BaseDeployment: rm.ToBaseAPIModel(),
+		UUID:           parseUUID(d.UUID),
+		BaseDeployment: d.ToBaseAPIModel(),
 	}
 }

--- a/internal/provider/models/translate_deployment.go
+++ b/internal/provider/models/translate_deployment.go
@@ -82,7 +82,7 @@ func DeploymentResourceToAPIModel(resourceModel DeploymentResourceModel) artiecl
 	}
 
 	apiModel := artieclient.Deployment{
-		UUID:            parseUUID(resourceModel.UUID),
+		UUID:            ParseOptionalUUID(resourceModel.UUID),
 		Name:            resourceModel.Name.ValueString(),
 		Status:          resourceModel.Status.ValueString(),
 		DestinationUUID: ParseOptionalUUID(resourceModel.DestinationUUID),

--- a/internal/provider/models/translate_deployment.go
+++ b/internal/provider/models/translate_deployment.go
@@ -64,7 +64,7 @@ func DeploymentAPIToResourceModel(apiModel artieclient.Deployment, resourceModel
 	}
 }
 
-func (d DeploymentResourceModel) ToBaseAPIModel() artieclient.BaseDeployment {
+func (d DeploymentResourceModel) ToAPIBaseModel() artieclient.BaseDeployment {
 	tables := []artieclient.Table{}
 	for _, table := range d.Source.Tables {
 		tableUUID := table.UUID.ValueString()
@@ -124,6 +124,6 @@ func (d DeploymentResourceModel) ToBaseAPIModel() artieclient.BaseDeployment {
 func (d DeploymentResourceModel) ToAPIModel() artieclient.Deployment {
 	return artieclient.Deployment{
 		UUID:           parseUUID(d.UUID),
-		BaseDeployment: d.ToBaseAPIModel(),
+		BaseDeployment: d.ToAPIBaseModel(),
 	}
 }


### PR DESCRIPTION
Also created a new struct called `BaseDeployment` which doesn't include the fields that are only set by our api (uuid and status) - this allows us to construct an api model for a deployment that hasn't been created yet. Now the client methods that can work on an unsaved deployment take a `BaseDeployment` instead of a full `Deployment`.

Will make the same change for destinations and ssh tunnels after this is merged.