### PR TITLE
Add a BaseDestination type 

### DIFF
--- a/internal/artieclient/destination.go
+++ b/internal/artieclient/destination.go
@@ -52,12 +52,10 @@ func (dc DestinationClient) Get(ctx context.Context, destinationUUID string) (De
 
 func (dc DestinationClient) Create(ctx context.Context, destination BaseDestination) (Destination, error) {
 	body := map[string]any{
-		"type":         destination.Type,
-		"label":        destination.Label,
-		"sharedConfig": destination.Config,
-	}
-	if destination.SSHTunnelUUID != nil {
-		body["sshTunnelUUID"] = *destination.SSHTunnelUUID
+		"type":          destination.Type,
+		"label":         destination.Label,
+		"sharedConfig":  destination.Config,
+		"sshTunnelUUID": destination.SSHTunnelUUID,
 	}
 	return makeRequest[Destination](ctx, dc.client, http.MethodPost, dc.basePath(), body)
 }

--- a/internal/artieclient/destination.go
+++ b/internal/artieclient/destination.go
@@ -9,12 +9,15 @@ import (
 	"github.com/google/uuid"
 )
 
-type Destination struct {
-	UUID          uuid.UUID               `json:"uuid"`
+type BaseDestination struct {
 	Type          string                  `json:"type"`
 	Label         string                  `json:"label"`
 	SSHTunnelUUID *uuid.UUID              `json:"sshTunnelUUID"`
 	Config        DestinationSharedConfig `json:"sharedConfig"`
+}
+type Destination struct {
+	BaseDestination
+	UUID uuid.UUID `json:"uuid"`
 }
 
 type DestinationSharedConfig struct {
@@ -47,14 +50,14 @@ func (dc DestinationClient) Get(ctx context.Context, destinationUUID string) (De
 	return makeRequest[Destination](ctx, dc.client, http.MethodGet, path, nil)
 }
 
-func (dc DestinationClient) Create(ctx context.Context, type_, label string, config DestinationSharedConfig, sshTunnelUUID *uuid.UUID) (Destination, error) {
+func (dc DestinationClient) Create(ctx context.Context, destination BaseDestination) (Destination, error) {
 	body := map[string]any{
-		"type":         type_,
-		"label":        label,
-		"sharedConfig": config,
+		"type":         destination.Type,
+		"label":        destination.Label,
+		"sharedConfig": destination.Config,
 	}
-	if sshTunnelUUID != nil {
-		body["sshTunnelUUID"] = *sshTunnelUUID
+	if destination.SSHTunnelUUID != nil {
+		body["sshTunnelUUID"] = *destination.SSHTunnelUUID
 	}
 	return makeRequest[Destination](ctx, dc.client, http.MethodPost, dc.basePath(), body)
 }
@@ -68,7 +71,7 @@ func (dc DestinationClient) Update(ctx context.Context, destination Destination)
 	return makeRequest[Destination](ctx, dc.client, http.MethodPost, path, destination)
 }
 
-func (dc DestinationClient) TestConnection(ctx context.Context, destination Destination) error {
+func (dc DestinationClient) TestConnection(ctx context.Context, destination BaseDestination) error {
 	path, err := url.JoinPath(dc.basePath(), "ping")
 	if err != nil {
 		return err

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -118,7 +118,7 @@ func (r *DestinationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	destination, err := r.client.Destinations().Create(ctx, models.DestinationResourceToBaseAPIModel(data))
+	destination, err := r.client.Destinations().Create(ctx, data.ToBaseAPIModel())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Create Destination", err.Error())
 		return
@@ -156,13 +156,13 @@ func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	baseDestination := models.DestinationResourceToBaseAPIModel(data)
+	baseDestination := data.ToBaseAPIModel()
 	if err := r.client.Destinations().TestConnection(ctx, baseDestination); err != nil {
 		resp.Diagnostics.AddError("Unable to Update Destination", err.Error())
 		return
 	}
 
-	fullDestination := models.DestinationResourceToAPIModel(data)
+	fullDestination := data.ToAPIModel()
 	updatedDestination, err := r.client.Destinations().Update(ctx, fullDestination)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update Destination", err.Error())

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -118,10 +118,7 @@ func (r *DestinationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	config := models.DestinationResourceToAPISharedConfigModel(data)
-	sshTunnelUUID := models.ParseOptionalUUID(data.SSHTunnelUUID)
-
-	destination, err := r.client.Destinations().Create(ctx, data.Type.ValueString(), data.Label.ValueString(), config, sshTunnelUUID)
+	destination, err := r.client.Destinations().Create(ctx, models.DestinationResourceToBaseAPIModel(data))
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Create Destination", err.Error())
 		return
@@ -159,20 +156,21 @@ func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	destination := models.DestinationResourceToAPIModel(data)
-	if err := r.client.Destinations().TestConnection(ctx, destination); err != nil {
+	baseDestination := models.DestinationResourceToBaseAPIModel(data)
+	if err := r.client.Destinations().TestConnection(ctx, baseDestination); err != nil {
 		resp.Diagnostics.AddError("Unable to Update Destination", err.Error())
 		return
 	}
 
-	destination, err := r.client.Destinations().Update(ctx, destination)
+	fullDestination := models.DestinationResourceToAPIModel(data)
+	updatedDestination, err := r.client.Destinations().Update(ctx, fullDestination)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update Destination", err.Error())
 		return
 	}
 
 	// Translate API response into Terraform state & save state
-	models.DestinationAPIToResourceModel(destination, &data)
+	models.DestinationAPIToResourceModel(updatedDestination, &data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/models/translate_destination.go
+++ b/internal/provider/models/translate_destination.go
@@ -37,38 +37,37 @@ func DestinationAPIToResourceModel(apiModel artieclient.Destination, resourceMod
 	}
 }
 
-func destinationResourceToAPISharedConfigModel(resourceModel DestinationResourceModel) artieclient.DestinationSharedConfig {
-	switch strings.ToLower(resourceModel.Type.ValueString()) {
+func (rm DestinationResourceModel) ToBaseAPIModel() artieclient.BaseDestination {
+	var sharedConfig artieclient.DestinationSharedConfig
+	switch strings.ToLower(rm.Type.ValueString()) {
 	case string(Snowflake):
-		return artieclient.DestinationSharedConfig{
-			SnowflakeAccountURL: resourceModel.SnowflakeConfig.AccountURL.ValueString(),
-			SnowflakeVirtualDWH: resourceModel.SnowflakeConfig.VirtualDWH.ValueString(),
-			SnowflakePrivateKey: resourceModel.SnowflakeConfig.PrivateKey.ValueString(),
-			Username:            resourceModel.SnowflakeConfig.Username.ValueString(),
-			Password:            resourceModel.SnowflakeConfig.Password.ValueString(),
+		sharedConfig = artieclient.DestinationSharedConfig{
+			SnowflakeAccountURL: rm.SnowflakeConfig.AccountURL.ValueString(),
+			SnowflakeVirtualDWH: rm.SnowflakeConfig.VirtualDWH.ValueString(),
+			SnowflakePrivateKey: rm.SnowflakeConfig.PrivateKey.ValueString(),
+			Username:            rm.SnowflakeConfig.Username.ValueString(),
+			Password:            rm.SnowflakeConfig.Password.ValueString(),
 		}
 	case string(BigQuery):
-		return artieclient.DestinationSharedConfig{
-			GCPProjectID:       resourceModel.BigQueryConfig.ProjectID.ValueString(),
-			GCPLocation:        resourceModel.BigQueryConfig.Location.ValueString(),
-			GCPCredentialsData: resourceModel.BigQueryConfig.CredentialsData.ValueString(),
+		sharedConfig = artieclient.DestinationSharedConfig{
+			GCPProjectID:       rm.BigQueryConfig.ProjectID.ValueString(),
+			GCPLocation:        rm.BigQueryConfig.Location.ValueString(),
+			GCPCredentialsData: rm.BigQueryConfig.CredentialsData.ValueString(),
 		}
 	case string(Redshift):
-		return artieclient.DestinationSharedConfig{
-			Endpoint: resourceModel.RedshiftConfig.Endpoint.ValueString(),
-			Username: resourceModel.RedshiftConfig.Username.ValueString(),
-			Password: resourceModel.RedshiftConfig.Password.ValueString(),
+		sharedConfig = artieclient.DestinationSharedConfig{
+			Endpoint: rm.RedshiftConfig.Endpoint.ValueString(),
+			Username: rm.RedshiftConfig.Username.ValueString(),
+			Password: rm.RedshiftConfig.Password.ValueString(),
 		}
 	default:
-		return artieclient.DestinationSharedConfig{}
+		sharedConfig = artieclient.DestinationSharedConfig{}
 	}
-}
 
-func (rm DestinationResourceModel) ToBaseAPIModel() artieclient.BaseDestination {
 	return artieclient.BaseDestination{
 		Type:          rm.Type.ValueString(),
 		Label:         rm.Label.ValueString(),
-		Config:        destinationResourceToAPISharedConfigModel(rm),
+		Config:        sharedConfig,
 		SSHTunnelUUID: ParseOptionalUUID(rm.SSHTunnelUUID),
 	}
 }

--- a/internal/provider/models/translate_destination.go
+++ b/internal/provider/models/translate_destination.go
@@ -64,12 +64,18 @@ func DestinationResourceToAPISharedConfigModel(resourceModel DestinationResource
 	}
 }
 
-func DestinationResourceToAPIModel(resourceModel DestinationResourceModel) artieclient.Destination {
-	return artieclient.Destination{
-		UUID:          parseUUID(resourceModel.UUID),
+func DestinationResourceToBaseAPIModel(resourceModel DestinationResourceModel) artieclient.BaseDestination {
+	return artieclient.BaseDestination{
 		Type:          resourceModel.Type.ValueString(),
 		Label:         resourceModel.Label.ValueString(),
 		Config:        DestinationResourceToAPISharedConfigModel(resourceModel),
 		SSHTunnelUUID: ParseOptionalUUID(resourceModel.SSHTunnelUUID),
+	}
+}
+
+func DestinationResourceToAPIModel(resourceModel DestinationResourceModel) artieclient.Destination {
+	return artieclient.Destination{
+		UUID:            parseUUID(resourceModel.UUID),
+		BaseDestination: DestinationResourceToBaseAPIModel(resourceModel),
 	}
 }

--- a/internal/provider/models/translate_destination.go
+++ b/internal/provider/models/translate_destination.go
@@ -37,7 +37,7 @@ func DestinationAPIToResourceModel(apiModel artieclient.Destination, resourceMod
 	}
 }
 
-func DestinationResourceToAPISharedConfigModel(resourceModel DestinationResourceModel) artieclient.DestinationSharedConfig {
+func destinationResourceToAPISharedConfigModel(resourceModel DestinationResourceModel) artieclient.DestinationSharedConfig {
 	switch strings.ToLower(resourceModel.Type.ValueString()) {
 	case string(Snowflake):
 		return artieclient.DestinationSharedConfig{
@@ -64,18 +64,18 @@ func DestinationResourceToAPISharedConfigModel(resourceModel DestinationResource
 	}
 }
 
-func DestinationResourceToBaseAPIModel(resourceModel DestinationResourceModel) artieclient.BaseDestination {
+func (rm DestinationResourceModel) ToBaseAPIModel() artieclient.BaseDestination {
 	return artieclient.BaseDestination{
-		Type:          resourceModel.Type.ValueString(),
-		Label:         resourceModel.Label.ValueString(),
-		Config:        DestinationResourceToAPISharedConfigModel(resourceModel),
-		SSHTunnelUUID: ParseOptionalUUID(resourceModel.SSHTunnelUUID),
+		Type:          rm.Type.ValueString(),
+		Label:         rm.Label.ValueString(),
+		Config:        destinationResourceToAPISharedConfigModel(rm),
+		SSHTunnelUUID: ParseOptionalUUID(rm.SSHTunnelUUID),
 	}
 }
 
-func DestinationResourceToAPIModel(resourceModel DestinationResourceModel) artieclient.Destination {
+func (rm DestinationResourceModel) ToAPIModel() artieclient.Destination {
 	return artieclient.Destination{
-		UUID:            parseUUID(resourceModel.UUID),
-		BaseDestination: DestinationResourceToBaseAPIModel(resourceModel),
+		UUID:            parseUUID(rm.UUID),
+		BaseDestination: rm.ToBaseAPIModel(),
 	}
 }


### PR DESCRIPTION
So we can pass around a destination object that doesn't have a uuid yet. Same pattern that's introduced in https://github.com/artie-labs/terraform-provider-artie/pull/70