### PR TITLE
Refactor SSH tunnel model

### DIFF
--- a/internal/artieclient/ssh_tunnel.go
+++ b/internal/artieclient/ssh_tunnel.go
@@ -39,13 +39,7 @@ func (sc SSHTunnelClient) Get(ctx context.Context, sshTunnelUUID string) (SSHTun
 }
 
 func (sc SSHTunnelClient) Create(ctx context.Context, sshTunnel BaseSSHTunnel) (SSHTunnel, error) {
-	body := map[string]any{
-		"name":     sshTunnel.Name,
-		"host":     sshTunnel.Host,
-		"port":     sshTunnel.Port,
-		"username": sshTunnel.Username,
-	}
-	return makeRequest[SSHTunnel](ctx, sc.client, http.MethodPost, sc.basePath(), body)
+	return makeRequest[SSHTunnel](ctx, sc.client, http.MethodPost, sc.basePath(), sshTunnel)
 }
 
 func (sc SSHTunnelClient) Update(ctx context.Context, sshTunnel SSHTunnel) (SSHTunnel, error) {

--- a/internal/artieclient/ssh_tunnel.go
+++ b/internal/artieclient/ssh_tunnel.go
@@ -8,13 +8,17 @@ import (
 	"github.com/google/uuid"
 )
 
+type BaseSSHTunnel struct {
+	Name      string `json:"name"`
+	Host      string `json:"host"`
+	Port      int32  `json:"port"`
+	Username  string `json:"username"`
+	PublicKey string `json:"publicKey"`
+}
+
 type SSHTunnel struct {
-	UUID      uuid.UUID `json:"uuid"`
-	Name      string    `json:"name"`
-	Host      string    `json:"host"`
-	Port      int32     `json:"port"`
-	Username  string    `json:"username"`
-	PublicKey string    `json:"publicKey"`
+	BaseSSHTunnel
+	UUID uuid.UUID `json:"uuid"`
 }
 
 type SSHTunnelClient struct {
@@ -34,12 +38,12 @@ func (sc SSHTunnelClient) Get(ctx context.Context, sshTunnelUUID string) (SSHTun
 	return makeRequest[SSHTunnel](ctx, sc.client, http.MethodGet, path, nil)
 }
 
-func (sc SSHTunnelClient) Create(ctx context.Context, name, host, username string, port int32) (SSHTunnel, error) {
+func (sc SSHTunnelClient) Create(ctx context.Context, sshTunnel BaseSSHTunnel) (SSHTunnel, error) {
 	body := map[string]any{
-		"name":     name,
-		"host":     host,
-		"port":     port,
-		"username": username,
+		"name":     sshTunnel.Name,
+		"host":     sshTunnel.Host,
+		"port":     sshTunnel.Port,
+		"username": sshTunnel.Username,
 	}
 	return makeRequest[SSHTunnel](ctx, sc.client, http.MethodPost, sc.basePath(), body)
 }

--- a/internal/provider/models/translate_ssh_tunnel.go
+++ b/internal/provider/models/translate_ssh_tunnel.go
@@ -6,13 +6,13 @@ import (
 	"terraform-provider-artie/internal/artieclient"
 )
 
-func SSHTunnelAPIToResourceModel(apiModel artieclient.SSHTunnel, resourceModel *SSHTunnelResourceModel) {
-	resourceModel.UUID = types.StringValue(apiModel.UUID.String())
-	resourceModel.Name = types.StringValue(apiModel.Name)
-	resourceModel.Host = types.StringValue(apiModel.Host)
-	resourceModel.Port = types.Int32Value(apiModel.Port)
-	resourceModel.Username = types.StringValue(apiModel.Username)
-	resourceModel.PublicKey = types.StringValue(apiModel.PublicKey)
+func (s *SSHTunnelResourceModel) FillFromAPIModel(apiModel artieclient.SSHTunnel) {
+	s.UUID = types.StringValue(apiModel.UUID.String())
+	s.Name = types.StringValue(apiModel.Name)
+	s.Host = types.StringValue(apiModel.Host)
+	s.Port = types.Int32Value(apiModel.Port)
+	s.Username = types.StringValue(apiModel.Username)
+	s.PublicKey = types.StringValue(apiModel.PublicKey)
 }
 
 func (s SSHTunnelResourceModel) ToAPIBaseModel() artieclient.BaseSSHTunnel {

--- a/internal/provider/models/translate_ssh_tunnel.go
+++ b/internal/provider/models/translate_ssh_tunnel.go
@@ -15,13 +15,19 @@ func SSHTunnelAPIToResourceModel(apiModel artieclient.SSHTunnel, resourceModel *
 	resourceModel.PublicKey = types.StringValue(apiModel.PublicKey)
 }
 
+func (s SSHTunnelResourceModel) ToBaseAPIModel() artieclient.BaseSSHTunnel {
+	return artieclient.BaseSSHTunnel{
+		Name:      s.Name.ValueString(),
+		Host:      s.Host.ValueString(),
+		Port:      s.Port.ValueInt32(),
+		Username:  s.Username.ValueString(),
+		PublicKey: s.PublicKey.ValueString(),
+	}
+}
+
 func SSHTunnelResourceToAPIModel(resourceModel SSHTunnelResourceModel) artieclient.SSHTunnel {
 	return artieclient.SSHTunnel{
-		UUID:      parseUUID(resourceModel.UUID),
-		Name:      resourceModel.Name.ValueString(),
-		Host:      resourceModel.Host.ValueString(),
-		Port:      resourceModel.Port.ValueInt32(),
-		Username:  resourceModel.Username.ValueString(),
-		PublicKey: resourceModel.PublicKey.ValueString(),
+		UUID:          parseUUID(resourceModel.UUID),
+		BaseSSHTunnel: resourceModel.ToBaseAPIModel(),
 	}
 }

--- a/internal/provider/models/translate_ssh_tunnel.go
+++ b/internal/provider/models/translate_ssh_tunnel.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-artie/internal/artieclient"
 )
 
-func (s *SSHTunnelResourceModel) FillFromAPIModel(apiModel artieclient.SSHTunnel) {
+func (s *SSHTunnelResourceModel) UpdateFromAPIModel(apiModel artieclient.SSHTunnel) {
 	s.UUID = types.StringValue(apiModel.UUID.String())
 	s.Name = types.StringValue(apiModel.Name)
 	s.Host = types.StringValue(apiModel.Host)

--- a/internal/provider/models/translate_ssh_tunnel.go
+++ b/internal/provider/models/translate_ssh_tunnel.go
@@ -15,7 +15,7 @@ func SSHTunnelAPIToResourceModel(apiModel artieclient.SSHTunnel, resourceModel *
 	resourceModel.PublicKey = types.StringValue(apiModel.PublicKey)
 }
 
-func (s SSHTunnelResourceModel) ToBaseAPIModel() artieclient.BaseSSHTunnel {
+func (s SSHTunnelResourceModel) ToAPIBaseModel() artieclient.BaseSSHTunnel {
 	return artieclient.BaseSSHTunnel{
 		Name:      s.Name.ValueString(),
 		Host:      s.Host.ValueString(),
@@ -28,6 +28,6 @@ func (s SSHTunnelResourceModel) ToBaseAPIModel() artieclient.BaseSSHTunnel {
 func (s SSHTunnelResourceModel) ToAPIModel() artieclient.SSHTunnel {
 	return artieclient.SSHTunnel{
 		UUID:          parseUUID(s.UUID),
-		BaseSSHTunnel: s.ToBaseAPIModel(),
+		BaseSSHTunnel: s.ToAPIBaseModel(),
 	}
 }

--- a/internal/provider/models/translate_ssh_tunnel.go
+++ b/internal/provider/models/translate_ssh_tunnel.go
@@ -25,9 +25,9 @@ func (s SSHTunnelResourceModel) ToBaseAPIModel() artieclient.BaseSSHTunnel {
 	}
 }
 
-func SSHTunnelResourceToAPIModel(resourceModel SSHTunnelResourceModel) artieclient.SSHTunnel {
+func (s SSHTunnelResourceModel) ToAPIModel() artieclient.SSHTunnel {
 	return artieclient.SSHTunnel{
-		UUID:          parseUUID(resourceModel.UUID),
-		BaseSSHTunnel: resourceModel.ToBaseAPIModel(),
+		UUID:          parseUUID(s.UUID),
+		BaseSSHTunnel: s.ToBaseAPIModel(),
 	}
 }

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -91,7 +91,7 @@ func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	sshTunnel, err := r.client.SSHTunnels().Create(ctx, data.ToBaseAPIModel())
+	sshTunnel, err := r.client.SSHTunnels().Create(ctx, data.ToAPIBaseModel())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Create SSH Tunnel", err.Error())
 		return

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -98,7 +98,7 @@ func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Translate API response into Terraform state & save state
-	data.FillFromAPIModel(sshTunnel)
+	data.UpdateFromAPIModel(sshTunnel)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -117,7 +117,7 @@ func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Translate API response into Terraform state & save state
-	data.FillFromAPIModel(sshTunnel)
+	data.UpdateFromAPIModel(sshTunnel)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -136,7 +136,7 @@ func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// Translate API response into Terraform state & save state
-	data.FillFromAPIModel(sshTunnel)
+	data.UpdateFromAPIModel(sshTunnel)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -98,7 +98,7 @@ func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Translate API response into Terraform state & save state
-	models.SSHTunnelAPIToResourceModel(sshTunnel, &data)
+	data.FillFromAPIModel(sshTunnel)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -117,7 +117,7 @@ func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Translate API response into Terraform state & save state
-	models.SSHTunnelAPIToResourceModel(sshTunnel, &data)
+	data.FillFromAPIModel(sshTunnel)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -136,7 +136,7 @@ func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// Translate API response into Terraform state & save state
-	models.SSHTunnelAPIToResourceModel(sshTunnel, &data)
+	data.FillFromAPIModel(sshTunnel)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -129,8 +129,7 @@ func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	sshTunnel := models.SSHTunnelResourceToAPIModel(data)
-	sshTunnel, err := r.client.SSHTunnels().Update(ctx, sshTunnel)
+	sshTunnel, err := r.client.SSHTunnels().Update(ctx, data.ToAPIModel())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Update SSH Tunnel", err.Error())
 		return

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -91,7 +91,7 @@ func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	sshTunnel, err := r.client.SSHTunnels().Create(ctx, data.Name.ValueString(), data.Host.ValueString(), data.Username.ValueString(), data.Port.ValueInt32())
+	sshTunnel, err := r.client.SSHTunnels().Create(ctx, data.ToBaseAPIModel())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Create SSH Tunnel", err.Error())
 		return


### PR DESCRIPTION
- Added a `BaseSSHTunnel` struct to represent an ssh tunnel that hasn't been saved yet (doesn't have a uuid)
- Made `artieclient.SSHTunnels().Create()` take a `BaseSSHTunnel` instead of a bunch of args
- Turned the translation functions into receiver methods on `SSHTunnelResourceModel` and gave them shorter, clearer names