### PR TITLE
Construct new state instead of overriding properties on plan data

### DIFF
--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -215,8 +215,8 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.DeploymentFromAPIModel(updatedDeployment)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.DeploymentFromAPIModel(updatedDeployment))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -234,8 +234,8 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.DeploymentFromAPIModel(deployment)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.DeploymentFromAPIModel(deployment))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -264,8 +264,8 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.DeploymentFromAPIModel(updatedDeployment)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.DeploymentFromAPIModel(updatedDeployment))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -215,8 +215,8 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Translate API response into Terraform model and save it into state
-	planData.UpdateFromAPIModel(updatedDeployment)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	newState := tfmodels.DeploymentFromAPIModel(updatedDeployment)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -234,8 +234,8 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Translate API response into Terraform model and save it into state
-	stateData.UpdateFromAPIModel(deployment)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	newState := tfmodels.DeploymentFromAPIModel(deployment)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -264,8 +264,8 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Translate API response into Terraform model and save it into state
-	planData.UpdateFromAPIModel(updatedDeployment)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	newState := tfmodels.DeploymentFromAPIModel(updatedDeployment)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -125,8 +125,8 @@ func (r *DestinationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.DestinationFromAPIModel(destination)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.DestinationFromAPIModel(destination))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *DestinationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -144,8 +144,8 @@ func (r *DestinationResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.DestinationFromAPIModel(destinationResp)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.DestinationFromAPIModel(destinationResp))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -169,8 +169,8 @@ func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.DestinationFromAPIModel(updatedDestination)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.DestinationFromAPIModel(updatedDestination))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *DestinationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -125,8 +125,8 @@ func (r *DestinationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Translate API response into Terraform model and save it into state
-	planData.UpdateFromAPIModel(destination)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	newState := tfmodels.DestinationFromAPIModel(destination)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *DestinationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -144,8 +144,8 @@ func (r *DestinationResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	// Translate API response into Terraform model and save it into state
-	stateData.UpdateFromAPIModel(destinationResp)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	newState := tfmodels.DestinationFromAPIModel(destinationResp)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -169,8 +169,8 @@ func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	// Translate API response into Terraform model and save it into state
-	planData.UpdateFromAPIModel(updatedDestination)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	newState := tfmodels.DestinationFromAPIModel(updatedDestination)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *DestinationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -98,8 +98,8 @@ func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.SSHTunnelFromAPIModel(sshTunnel)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.SSHTunnelFromAPIModel(sshTunnel))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -117,8 +117,8 @@ func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.SSHTunnelFromAPIModel(sshTunnel)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.SSHTunnelFromAPIModel(sshTunnel))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -136,8 +136,8 @@ func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// Translate API response into Terraform model and save it into state
-	newState := tfmodels.SSHTunnelFromAPIModel(sshTunnel)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	diagnostics := resp.State.Set(ctx, tfmodels.SSHTunnelFromAPIModel(sshTunnel))
+	resp.Diagnostics.Append(diagnostics...)
 }
 
 func (r *SSHTunnelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -98,8 +98,8 @@ func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Translate API response into Terraform model and save it into state
-	planData.UpdateFromAPIModel(sshTunnel)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	newState := tfmodels.SSHTunnelFromAPIModel(sshTunnel)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -117,8 +117,8 @@ func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Translate API response into Terraform model and save it into state
-	stateData.UpdateFromAPIModel(sshTunnel)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+	newState := tfmodels.SSHTunnelFromAPIModel(sshTunnel)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -136,8 +136,8 @@ func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// Translate API response into Terraform model and save it into state
-	planData.UpdateFromAPIModel(sshTunnel)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	newState := tfmodels.SSHTunnelFromAPIModel(sshTunnel)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
 func (r *SSHTunnelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -36,15 +36,17 @@ func (d Deployment) ToAPIModel() artieclient.Deployment {
 	}
 }
 
-func (d *Deployment) UpdateFromAPIModel(apiModel artieclient.Deployment) {
-	d.UUID = types.StringValue(apiModel.UUID.String())
-	d.Name = types.StringValue(apiModel.Name)
-	d.Status = types.StringValue(apiModel.Status)
-	d.DestinationUUID = optionalUUIDToStringValue(apiModel.DestinationUUID)
-	d.SSHTunnelUUID = optionalUUIDToStringValue(apiModel.SSHTunnelUUID)
-	d.SnowflakeEcoScheduleUUID = optionalUUIDToStringValue(apiModel.SnowflakeEcoScheduleUUID)
-	d.Source = SourceFromAPIModel(apiModel.Source)
-	d.DestinationConfig = DeploymentDestinationConfigFromAPIModel(apiModel.DestinationConfig)
+func DeploymentFromAPIModel(apiModel artieclient.Deployment) Deployment {
+	return Deployment{
+		UUID:                     types.StringValue(apiModel.UUID.String()),
+		Name:                     types.StringValue(apiModel.Name),
+		Status:                   types.StringValue(apiModel.Status),
+		Source:                   SourceFromAPIModel(apiModel.Source),
+		DestinationUUID:          optionalUUIDToStringValue(apiModel.DestinationUUID),
+		DestinationConfig:        DeploymentDestinationConfigFromAPIModel(apiModel.DestinationConfig),
+		SSHTunnelUUID:            optionalUUIDToStringValue(apiModel.SSHTunnelUUID),
+		SnowflakeEcoScheduleUUID: optionalUUIDToStringValue(apiModel.SnowflakeEcoScheduleUUID),
+	}
 }
 
 type DeploymentDestinationConfig struct {

--- a/internal/provider/tfmodels/destination.go
+++ b/internal/provider/tfmodels/destination.go
@@ -90,25 +90,26 @@ func SnowflakeSharedConfigFromAPIModel(apiModel artieclient.DestinationSharedCon
 	}
 }
 
-func (d *Destination) UpdateFromAPIModel(apiModel artieclient.Destination) {
-	d.UUID = types.StringValue(apiModel.UUID.String())
-	d.Type = types.StringValue(string(apiModel.Type))
-	d.Label = types.StringValue(apiModel.Label)
-	d.SSHTunnelUUID = optionalUUIDToStringValue(apiModel.SSHTunnelUUID)
-	d.BigQueryConfig = nil
-	d.RedshiftConfig = nil
-	d.SnowflakeConfig = nil
+func DestinationFromAPIModel(apiModel artieclient.Destination) Destination {
+	destination := Destination{
+		UUID:          types.StringValue(apiModel.UUID.String()),
+		Type:          types.StringValue(string(apiModel.Type)),
+		Label:         types.StringValue(apiModel.Label),
+		SSHTunnelUUID: optionalUUIDToStringValue(apiModel.SSHTunnelUUID),
+	}
 
 	switch apiModel.Type {
 	case artieclient.BigQuery:
-		d.BigQueryConfig = BigQuerySharedConfigFromAPIModel(apiModel.Config)
+		destination.BigQueryConfig = BigQuerySharedConfigFromAPIModel(apiModel.Config)
 	case artieclient.Redshift:
-		d.RedshiftConfig = RedshiftSharedConfigFromAPIModel(apiModel.Config)
+		destination.RedshiftConfig = RedshiftSharedConfigFromAPIModel(apiModel.Config)
 	case artieclient.Snowflake:
-		d.SnowflakeConfig = SnowflakeSharedConfigFromAPIModel(apiModel.Config)
+		destination.SnowflakeConfig = SnowflakeSharedConfigFromAPIModel(apiModel.Config)
 	default:
 		panic(fmt.Sprintf("invalid destination type: %s", apiModel.Type))
 	}
+
+	return destination
 }
 
 func (d Destination) ToAPIBaseModel() artieclient.BaseDestination {

--- a/internal/provider/tfmodels/ssh_tunnel.go
+++ b/internal/provider/tfmodels/ssh_tunnel.go
@@ -15,13 +15,15 @@ type SSHTunnel struct {
 	PublicKey types.String `tfsdk:"public_key"`
 }
 
-func (s *SSHTunnel) UpdateFromAPIModel(apiModel artieclient.SSHTunnel) {
-	s.UUID = types.StringValue(apiModel.UUID.String())
-	s.Name = types.StringValue(apiModel.Name)
-	s.Host = types.StringValue(apiModel.Host)
-	s.Port = types.Int32Value(apiModel.Port)
-	s.Username = types.StringValue(apiModel.Username)
-	s.PublicKey = types.StringValue(apiModel.PublicKey)
+func SSHTunnelFromAPIModel(apiModel artieclient.SSHTunnel) SSHTunnel {
+	return SSHTunnel{
+		UUID:      types.StringValue(apiModel.UUID.String()),
+		Name:      types.StringValue(apiModel.Name),
+		Host:      types.StringValue(apiModel.Host),
+		Port:      types.Int32Value(apiModel.Port),
+		Username:  types.StringValue(apiModel.Username),
+		PublicKey: types.StringValue(apiModel.PublicKey),
+	}
 }
 
 func (s SSHTunnel) ToAPIBaseModel() artieclient.BaseSSHTunnel {


### PR DESCRIPTION
Replaced the `UpdateFromAPIModel()` methods with functions that build up a fully new object instead of taking the existing one and updating all the properties. This removes the need to nil out the other destination configs, and makes the calling code more clear.