### PR TITLE
Don't need this flag anymore when updating a deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+secret.tfvars
 bin/
 dist/
 modules-dev/

--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -122,9 +122,8 @@ func (dc DeploymentClient) Update(ctx context.Context, deployment Deployment) (D
 	}
 
 	body := map[string]any{
-		"deploy":           deployment,
-		"updateDeployOnly": true,
-		"startDeploy":      true,
+		"deploy":      deployment,
+		"startDeploy": true,
 	}
 
 	response, err := makeRequest[deploymentAPIResponse](ctx, dc.client, http.MethodPost, path, body)


### PR DESCRIPTION
After https://github.com/artie-labs/dashboard/pull/3243, the endpoint for updating a deployment no longer takes this flag.