### PR TITLE
Pass diagnostics to helper functions as pointers so changes are preserved

### DIFF
--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -178,25 +178,25 @@ func (r *DeploymentResource) Configure(ctx context.Context, req resource.Configu
 	r.client = client
 }
 
-func (r *DeploymentResource) GetUUIDFromState(ctx context.Context, state tfsdk.State, diagnostics diag.Diagnostics) (string, bool) {
+func (r *DeploymentResource) GetUUIDFromState(ctx context.Context, state tfsdk.State, diagnostics *diag.Diagnostics) (string, bool) {
 	var stateData tfmodels.Deployment
 	diagnostics.Append(state.Get(ctx, &stateData)...)
 	return stateData.UUID.ValueString(), diagnostics.HasError()
 }
 
-func (r *DeploymentResource) GetPlanData(ctx context.Context, plan tfsdk.Plan, diagnostics diag.Diagnostics) (tfmodels.Deployment, bool) {
+func (r *DeploymentResource) GetPlanData(ctx context.Context, plan tfsdk.Plan, diagnostics *diag.Diagnostics) (tfmodels.Deployment, bool) {
 	var planData tfmodels.Deployment
 	diagnostics.Append(plan.Get(ctx, &planData)...)
 	return planData, diagnostics.HasError()
 }
 
-func (r *DeploymentResource) SetStateData(ctx context.Context, state *tfsdk.State, diagnostics diag.Diagnostics, deployment artieclient.Deployment) {
+func (r *DeploymentResource) SetStateData(ctx context.Context, state *tfsdk.State, diagnostics *diag.Diagnostics, deployment artieclient.Deployment) {
 	// Translate API response type into Terraform model and save it into state
 	diagnostics.Append(state.Set(ctx, tfmodels.DeploymentFromAPIModel(deployment))...)
 }
 
 func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	planData, hasError := r.GetPlanData(ctx, req.Plan, resp.Diagnostics)
+	planData, hasError := r.GetPlanData(ctx, req.Plan, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -219,11 +219,11 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, createdDeployment)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, createdDeployment)
 }
 
 func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	deploymentUUID, hasError := r.GetUUIDFromState(ctx, req.State, resp.Diagnostics)
+	deploymentUUID, hasError := r.GetUUIDFromState(ctx, req.State, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -234,11 +234,11 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, deployment)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, deployment)
 }
 
 func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	planData, hasError := r.GetPlanData(ctx, req.Plan, resp.Diagnostics)
+	planData, hasError := r.GetPlanData(ctx, req.Plan, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -260,11 +260,11 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, updatedDeployment)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, updatedDeployment)
 }
 
 func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	deploymentUUID, hasError := r.GetUUIDFromState(ctx, req.State, resp.Diagnostics)
+	deploymentUUID, hasError := r.GetUUIDFromState(ctx, req.State, &resp.Diagnostics)
 	if hasError {
 		return
 	}

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -106,25 +106,25 @@ func (r *DestinationResource) Configure(ctx context.Context, req resource.Config
 	r.client = client
 }
 
-func (r *DestinationResource) GetUUIDFromState(ctx context.Context, state tfsdk.State, diagnostics diag.Diagnostics) (string, bool) {
+func (r *DestinationResource) GetUUIDFromState(ctx context.Context, state tfsdk.State, diagnostics *diag.Diagnostics) (string, bool) {
 	var stateData tfmodels.Destination
 	diagnostics.Append(state.Get(ctx, &stateData)...)
 	return stateData.UUID.ValueString(), diagnostics.HasError()
 }
 
-func (r *DestinationResource) GetPlanData(ctx context.Context, plan tfsdk.Plan, diagnostics diag.Diagnostics) (tfmodels.Destination, bool) {
+func (r *DestinationResource) GetPlanData(ctx context.Context, plan tfsdk.Plan, diagnostics *diag.Diagnostics) (tfmodels.Destination, bool) {
 	var planData tfmodels.Destination
 	diagnostics.Append(plan.Get(ctx, &planData)...)
 	return planData, diagnostics.HasError()
 }
 
-func (r *DestinationResource) SetStateData(ctx context.Context, state *tfsdk.State, diagnostics diag.Diagnostics, destination artieclient.Destination) {
+func (r *DestinationResource) SetStateData(ctx context.Context, state *tfsdk.State, diagnostics *diag.Diagnostics, destination artieclient.Destination) {
 	// Translate API response type into Terraform model and save it into state
 	diagnostics.Append(state.Set(ctx, tfmodels.DestinationFromAPIModel(destination))...)
 }
 
 func (r *DestinationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	planData, hasError := r.GetPlanData(ctx, req.Plan, resp.Diagnostics)
+	planData, hasError := r.GetPlanData(ctx, req.Plan, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -141,11 +141,11 @@ func (r *DestinationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, destination)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, destination)
 }
 
 func (r *DestinationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	destinationUUID, hasError := r.GetUUIDFromState(ctx, req.State, resp.Diagnostics)
+	destinationUUID, hasError := r.GetUUIDFromState(ctx, req.State, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -156,11 +156,11 @@ func (r *DestinationResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, destination)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, destination)
 }
 
 func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	planData, hasError := r.GetPlanData(ctx, req.Plan, resp.Diagnostics)
+	planData, hasError := r.GetPlanData(ctx, req.Plan, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -176,11 +176,11 @@ func (r *DestinationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, updatedDestination)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, updatedDestination)
 }
 
 func (r *DestinationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	destinationUUID, hasError := r.GetUUIDFromState(ctx, req.State, resp.Diagnostics)
+	destinationUUID, hasError := r.GetUUIDFromState(ctx, req.State, &resp.Diagnostics)
 	if hasError {
 		return
 	}

--- a/internal/provider/ssh_tunnel_resource.go
+++ b/internal/provider/ssh_tunnel_resource.go
@@ -85,25 +85,25 @@ func (r *SSHTunnelResource) Configure(ctx context.Context, req resource.Configur
 	r.client = client
 }
 
-func (r *SSHTunnelResource) GetUUIDFromState(ctx context.Context, state tfsdk.State, diagnostics diag.Diagnostics) (string, bool) {
+func (r *SSHTunnelResource) GetUUIDFromState(ctx context.Context, state tfsdk.State, diagnostics *diag.Diagnostics) (string, bool) {
 	var stateData tfmodels.SSHTunnel
 	diagnostics.Append(state.Get(ctx, &stateData)...)
 	return stateData.UUID.ValueString(), diagnostics.HasError()
 }
 
-func (r *SSHTunnelResource) GetPlanData(ctx context.Context, plan tfsdk.Plan, diagnostics diag.Diagnostics) (tfmodels.SSHTunnel, bool) {
+func (r *SSHTunnelResource) GetPlanData(ctx context.Context, plan tfsdk.Plan, diagnostics *diag.Diagnostics) (tfmodels.SSHTunnel, bool) {
 	var planData tfmodels.SSHTunnel
 	diagnostics.Append(plan.Get(ctx, &planData)...)
 	return planData, diagnostics.HasError()
 }
 
-func (r *SSHTunnelResource) SetStateData(ctx context.Context, state *tfsdk.State, diagnostics diag.Diagnostics, sshTunnel artieclient.SSHTunnel) {
+func (r *SSHTunnelResource) SetStateData(ctx context.Context, state *tfsdk.State, diagnostics *diag.Diagnostics, sshTunnel artieclient.SSHTunnel) {
 	// Translate API response type into Terraform model and save it into state
 	diagnostics.Append(state.Set(ctx, tfmodels.SSHTunnelFromAPIModel(sshTunnel))...)
 }
 
 func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	planData, hasError := r.GetPlanData(ctx, req.Plan, resp.Diagnostics)
+	planData, hasError := r.GetPlanData(ctx, req.Plan, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -114,11 +114,11 @@ func (r *SSHTunnelResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, sshTunnel)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, sshTunnel)
 }
 
 func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	tunnelUUID, hasError := r.GetUUIDFromState(ctx, req.State, resp.Diagnostics)
+	tunnelUUID, hasError := r.GetUUIDFromState(ctx, req.State, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -129,11 +129,11 @@ func (r *SSHTunnelResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, sshTunnel)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, sshTunnel)
 }
 
 func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	planData, hasError := r.GetPlanData(ctx, req.Plan, resp.Diagnostics)
+	planData, hasError := r.GetPlanData(ctx, req.Plan, &resp.Diagnostics)
 	if hasError {
 		return
 	}
@@ -144,11 +144,11 @@ func (r *SSHTunnelResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	r.SetStateData(ctx, &resp.State, resp.Diagnostics, sshTunnel)
+	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, sshTunnel)
 }
 
 func (r *SSHTunnelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	tunnelUUID, hasError := r.GetUUIDFromState(ctx, req.State, resp.Diagnostics)
+	tunnelUUID, hasError := r.GetUUIDFromState(ctx, req.State, &resp.Diagnostics)
 	if hasError {
 		return
 	}


### PR DESCRIPTION
Just realized that if an error happens in a helper function, it wasn't getting reported because we were passing the diagnostics to those functions without pointers so they didn't get directly mutated.