### PR TITLE
Handle 204 no content responses

### DIFF
--- a/internal/artieclient/client.go
+++ b/internal/artieclient/client.go
@@ -87,11 +87,11 @@ func (c Client) makeRequest(ctx context.Context, method string, path string, bod
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode >= 300 {
 		return buildError(resp)
 	}
 
-	if out != nil {
+	if out != nil && resp.StatusCode != http.StatusNoContent {
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 			return fmt.Errorf("artie-client: failed to decode response body: %w", err)
 		}


### PR DESCRIPTION
Some of our api endpoints now return 204 (no content) if they succeed and no response content is needed (e.g. validating and deleting objects). The provider was only accepting explicit 200s as success responses; instead it should accept anything in the 1xx or 2xx range.