### PR TITLE
`parseUUID` improvements

### DIFF
--- a/internal/provider/tfmodels/deployment_table.go
+++ b/internal/provider/tfmodels/deployment_table.go
@@ -36,22 +36,13 @@ func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnost
 	var diags diag.Diagnostics
 	if t.UUID.ValueString() != "" {
 		tableUUID, diags = parseUUID(t.UUID)
-		if diags.HasError() {
-			return artieclient.Table{}, diags
-		}
 	}
 
 	colsToExclude, excludeDiags := parseOptionalStringList(ctx, t.ExcludeColumns)
 	diags.Append(excludeDiags...)
-	if diags.HasError() {
-		return artieclient.Table{}, diags
-	}
 
 	colsToHash, hashDiags := parseOptionalStringList(ctx, t.ColumnsToHash)
 	diags.Append(hashDiags...)
-	if diags.HasError() {
-		return artieclient.Table{}, diags
-	}
 
 	var mergePredicates *[]artieclient.MergePredicate
 	if t.MergePredicates != nil {
@@ -60,6 +51,10 @@ func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnost
 			preds = append(preds, artieclient.MergePredicate{PartitionField: mp.PartitionField})
 		}
 		mergePredicates = &preds
+	}
+
+	if diags.HasError() {
+		return artieclient.Table{}, diags
 	}
 
 	return artieclient.Table{
@@ -74,27 +69,23 @@ func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnost
 		ColumnsToHash:        colsToHash,
 		SkipDeletes:          parseOptionalBool(t.SkipDeletes),
 		MergePredicates:      mergePredicates,
-	}, nil
+	}, diags
 }
 
 func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table) (map[string]Table, diag.Diagnostics) {
 	tables := map[string]Table{}
+	var diags diag.Diagnostics
 	for _, apiTable := range apiModelTables {
 		tableKey := apiTable.Name
 		if apiTable.Schema != "" {
 			tableKey = fmt.Sprintf("%s.%s", apiTable.Schema, apiTable.Name)
 		}
 
-		colsToExclude, diags := optionalStringListToStringValue(ctx, apiTable.ExcludeColumns)
-		if diags.HasError() {
-			return map[string]Table{}, diags
-		}
+		colsToExclude, excludeDiags := optionalStringListToStringValue(ctx, apiTable.ExcludeColumns)
+		diags.Append(excludeDiags...)
 
 		colsToHash, hashDiags := optionalStringListToStringValue(ctx, apiTable.ColumnsToHash)
 		diags.Append(hashDiags...)
-		if diags.HasError() {
-			return map[string]Table{}, diags
-		}
 
 		var mergePredicates *[]MergePredicate
 		if apiTable.MergePredicates != nil {
@@ -120,5 +111,9 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 		}
 	}
 
-	return tables, nil
+	if diags.HasError() {
+		return map[string]Table{}, diags
+	}
+
+	return tables, diags
 }

--- a/internal/provider/tfmodels/deployment_table.go
+++ b/internal/provider/tfmodels/deployment_table.go
@@ -33,11 +33,16 @@ type Table struct {
 
 func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnostics) {
 	tableUUID := uuid.Nil
+	var diags diag.Diagnostics
 	if t.UUID.ValueString() != "" {
-		tableUUID = uuid.MustParse(t.UUID.ValueString())
+		tableUUID, diags = parseUUID(t.UUID)
+		if diags.HasError() {
+			return artieclient.Table{}, diags
+		}
 	}
 
-	colsToExclude, diags := parseOptionalStringList(ctx, t.ExcludeColumns)
+	colsToExclude, excludeDiags := parseOptionalStringList(ctx, t.ExcludeColumns)
+	diags.Append(excludeDiags...)
 	if diags.HasError() {
 		return artieclient.Table{}, diags
 	}

--- a/internal/provider/tfmodels/util.go
+++ b/internal/provider/tfmodels/util.go
@@ -14,7 +14,7 @@ func ToPtr[T any](v T) *T {
 }
 
 func parseUUID(value types.String) (uuid.UUID, diag.Diagnostics) {
-	if value.IsNull() || len(value.ValueString()) == 0 {
+	if value.ValueString() == "" {
 		return uuid.UUID{}, []diag.Diagnostic{diag.NewErrorDiagnostic("UUID is empty", "")}
 	}
 
@@ -27,7 +27,7 @@ func parseUUID(value types.String) (uuid.UUID, diag.Diagnostics) {
 }
 
 func ParseOptionalUUID(value types.String) (*uuid.UUID, diag.Diagnostics) {
-	if value.IsNull() || len(value.ValueString()) == 0 {
+	if value.ValueString() == "" {
 		return nil, nil
 	}
 

--- a/internal/provider/tfmodels/util.go
+++ b/internal/provider/tfmodels/util.go
@@ -14,6 +14,10 @@ func ToPtr[T any](v T) *T {
 }
 
 func parseUUID(value types.String) (uuid.UUID, diag.Diagnostics) {
+	if value.IsNull() || len(value.ValueString()) == 0 {
+		return uuid.UUID{}, []diag.Diagnostic{diag.NewErrorDiagnostic("UUID is empty", "")}
+	}
+
 	u, err := uuid.Parse(value.ValueString())
 	if err != nil {
 		return uuid.UUID{}, []diag.Diagnostic{diag.NewErrorDiagnostic("Unable to parse UUID", fmt.Sprintf("value: %q", value.ValueString()))}


### PR DESCRIPTION
- Checking if a uuid is null/empty before trying to parse it
- One more place that was using `MustParse` instead of surfacing diagnostics
