### PR TITLE
Unnest advanced settings after creating a deployment

### DIFF
--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -180,7 +180,11 @@ func (dc DeploymentClient) Create(ctx context.Context, deployment BaseDeployment
 		"deployment":      deployment,
 		"startDeployment": true,
 	}
-	return makeRequest[Deployment](ctx, dc.client, http.MethodPost, dc.basePath(), body)
+	deploymentResp, err := makeRequest[deploymentWithAdvSettings](ctx, dc.client, http.MethodPost, dc.basePath(), body)
+	if err != nil {
+		return Deployment{}, err
+	}
+	return deploymentResp.unnestAdvSettings(), nil
 }
 
 func (dc DeploymentClient) Update(ctx context.Context, deployment Deployment) (Deployment, error) {


### PR DESCRIPTION
We were only doing this to the response from the Get & Update endpoints; need to do it for Create too, or else you get an inconsistent state error if you create a deployment with some advanced settings specified.