### PR TITLE
Supporting `data_plane_name` for deployment

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -62,7 +62,7 @@ resource "artie_deployment" "postgres_to_snowflake" {
 
 ### Optional
 
-- `data_plane_name` (String) The name of the data plane to use for this deployment. If this is not set, we will use the default data plane for your account. To see the full list of supported data planes on your account, click on `Create deployment` or perform a GET request to `https://api.artie.com/config`
+- `data_plane_name` (String) The name of the data plane to use for this deployment. If this is not set, we will use the default data plane for your account. To see the full list of supported data planes on your account, click on `Create deployment`
 - `drop_deleted_columns` (Boolean) If set to true, when a column is dropped from the source it will also be dropped in the destination.
 - `include_artie_updated_at_column` (Boolean) If set to true, Artie will add a new column to your dataset called __artie_updated_at.
 - `include_database_updated_at_column` (Boolean) If set to true, Artie will add a new column to your dataset called __artie_db_updated_at.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -62,6 +62,7 @@ resource "artie_deployment" "postgres_to_snowflake" {
 
 ### Optional
 
+- `data_plane_name` (String) The name of the data plane to use for this deployment. If this is not set, we will use the default data plane for your account. To see the full list of supported data planes on your account, click on `Create deployment` or perform a GET request to `https://api.artie.com/config`
 - `drop_deleted_columns` (Boolean) If set to true, when a column is dropped from the source it will also be dropped in the destination.
 - `include_artie_updated_at_column` (Boolean) If set to true, Artie will add a new column to your dataset called __artie_updated_at.
 - `include_database_updated_at_column` (Boolean) If set to true, Artie will add a new column to your dataset called __artie_db_updated_at.

--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -18,11 +18,12 @@ type BaseDeployment struct {
 	SnowflakeEcoScheduleUUID *uuid.UUID        `json:"snowflakeEcoScheduleUUID"`
 
 	// Advanced settings - these must all be nullable
-	DropDeletedColumns             *bool `json:"dropDeletedColumns"`
-	EnableSoftDelete               *bool `json:"enableSoftDelete"`
-	IncludeArtieUpdatedAtColumn    *bool `json:"includeArtieUpdatedAtColumn"`
-	IncludeDatabaseUpdatedAtColumn *bool `json:"includeDatabaseUpdatedAtColumn"`
-	OneTopicPerSchema              *bool `json:"oneTopicPerSchema"`
+	DataPlaneName                  *string `json:"dataPlaneName"`
+	DropDeletedColumns             *bool   `json:"dropDeletedColumns"`
+	EnableSoftDelete               *bool   `json:"enableSoftDelete"`
+	IncludeArtieUpdatedAtColumn    *bool   `json:"includeArtieUpdatedAtColumn"`
+	IncludeDatabaseUpdatedAtColumn *bool   `json:"includeDatabaseUpdatedAtColumn"`
+	OneTopicPerSchema              *bool   `json:"oneTopicPerSchema"`
 }
 
 type Deployment struct {

--- a/internal/artieclient/deployment.go
+++ b/internal/artieclient/deployment.go
@@ -16,14 +16,14 @@ type BaseDeployment struct {
 	DestinationConfig        DestinationConfig `json:"specificDestCfg"`
 	SSHTunnelUUID            *uuid.UUID        `json:"sshTunnelUUID"`
 	SnowflakeEcoScheduleUUID *uuid.UUID        `json:"snowflakeEcoScheduleUUID"`
+	DataPlaneName            string            `json:"dataPlaneName"`
 
 	// Advanced settings - these must all be nullable
-	DataPlaneName                  *string `json:"dataPlaneName"`
-	DropDeletedColumns             *bool   `json:"dropDeletedColumns"`
-	EnableSoftDelete               *bool   `json:"enableSoftDelete"`
-	IncludeArtieUpdatedAtColumn    *bool   `json:"includeArtieUpdatedAtColumn"`
-	IncludeDatabaseUpdatedAtColumn *bool   `json:"includeDatabaseUpdatedAtColumn"`
-	OneTopicPerSchema              *bool   `json:"oneTopicPerSchema"`
+	DropDeletedColumns             *bool `json:"dropDeletedColumns"`
+	EnableSoftDelete               *bool `json:"enableSoftDelete"`
+	IncludeArtieUpdatedAtColumn    *bool `json:"includeArtieUpdatedAtColumn"`
+	IncludeDatabaseUpdatedAtColumn *bool `json:"includeDatabaseUpdatedAtColumn"`
+	OneTopicPerSchema              *bool `json:"oneTopicPerSchema"`
 }
 
 type Deployment struct {

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -240,6 +240,13 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 					},
 				},
 			},
+			"data_plane_name": schema.StringAttribute{
+				MarkdownDescription: "The name of the data plane to use for this deployment. If this is not set, we will use the default data plane for your account. To see the full list of supported data planes on your account, click on `Create deployment` or perform a GET request to `https://api.artie.com/config`",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 			"drop_deleted_columns":               schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}, MarkdownDescription: "If set to true, when a column is dropped from the source it will also be dropped in the destination."},
 			"soft_delete_rows":                   schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}, MarkdownDescription: "If set to true, a new boolean column called __artie_delete will be added to your destination to indicate if the row has been deleted."},
 			"include_artie_updated_at_column":    schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}, MarkdownDescription: "If set to true, Artie will add a new column to your dataset called __artie_updated_at."},

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -241,7 +241,7 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 			},
 			"data_plane_name": schema.StringAttribute{
-				MarkdownDescription: "The name of the data plane to use for this deployment. If this is not set, we will use the default data plane for your account. To see the full list of supported data planes on your account, click on `Create deployment` or perform a GET request to `https://api.artie.com/config`",
+				MarkdownDescription: "The name of the data plane to use for this deployment. If this is not set, we will use the default data plane for your account. To see the full list of supported data planes on your account, click on `Create deployment`",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString(""),

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -60,7 +60,7 @@ func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeploym
 		SSHTunnelUUID:            sshTunnelUUID,
 		SnowflakeEcoScheduleUUID: snowflakeEcoScheduleUUID,
 		// Advanced settings:
-		DataPlaneName:                  d.DataPlaneName.ValueStringPointer(),
+		DataPlaneName:                  d.DataPlaneName.ValueString(),
 		DropDeletedColumns:             d.DropDeletedColumns.ValueBoolPointer(),
 		EnableSoftDelete:               d.SoftDeleteRows.ValueBoolPointer(),
 		IncludeArtieUpdatedAtColumn:    d.IncludeArtieUpdatedAtColumn.ValueBoolPointer(),
@@ -106,7 +106,7 @@ func DeploymentFromAPIModel(ctx context.Context, apiModel artieclient.Deployment
 		SnowflakeEcoScheduleUUID: optionalUUIDToStringValue(apiModel.SnowflakeEcoScheduleUUID),
 
 		// Advanced settings:
-		DataPlaneName:                  types.StringPointerValue(apiModel.DataPlaneName),
+		DataPlaneName:                  types.StringValue(apiModel.DataPlaneName),
 		DropDeletedColumns:             types.BoolPointerValue(apiModel.DropDeletedColumns),
 		SoftDeleteRows:                 types.BoolPointerValue(apiModel.EnableSoftDelete),
 		IncludeArtieUpdatedAtColumn:    types.BoolPointerValue(apiModel.IncludeArtieUpdatedAtColumn),

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -59,8 +59,8 @@ func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeploym
 		DestinationConfig:        d.DestinationConfig.ToAPIModel(),
 		SSHTunnelUUID:            sshTunnelUUID,
 		SnowflakeEcoScheduleUUID: snowflakeEcoScheduleUUID,
+		DataPlaneName:            d.DataPlaneName.ValueString(),
 		// Advanced settings:
-		DataPlaneName:                  d.DataPlaneName.ValueString(),
 		DropDeletedColumns:             d.DropDeletedColumns.ValueBoolPointer(),
 		EnableSoftDelete:               d.SoftDeleteRows.ValueBoolPointer(),
 		IncludeArtieUpdatedAtColumn:    d.IncludeArtieUpdatedAtColumn.ValueBoolPointer(),
@@ -104,9 +104,9 @@ func DeploymentFromAPIModel(ctx context.Context, apiModel artieclient.Deployment
 		DestinationConfig:        &destinationConfig,
 		SSHTunnelUUID:            optionalUUIDToStringValue(apiModel.SSHTunnelUUID),
 		SnowflakeEcoScheduleUUID: optionalUUIDToStringValue(apiModel.SnowflakeEcoScheduleUUID),
+		DataPlaneName:            types.StringValue(apiModel.DataPlaneName),
 
 		// Advanced settings:
-		DataPlaneName:                  types.StringValue(apiModel.DataPlaneName),
 		DropDeletedColumns:             types.BoolPointerValue(apiModel.DropDeletedColumns),
 		SoftDeleteRows:                 types.BoolPointerValue(apiModel.EnableSoftDelete),
 		IncludeArtieUpdatedAtColumn:    types.BoolPointerValue(apiModel.IncludeArtieUpdatedAtColumn),

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -20,11 +20,12 @@ type Deployment struct {
 	SnowflakeEcoScheduleUUID types.String                 `tfsdk:"snowflake_eco_schedule_uuid"`
 
 	// Advanced settings
-	DropDeletedColumns             types.Bool `tfsdk:"drop_deleted_columns"`
-	SoftDeleteRows                 types.Bool `tfsdk:"soft_delete_rows"`
-	IncludeArtieUpdatedAtColumn    types.Bool `tfsdk:"include_artie_updated_at_column"`
-	IncludeDatabaseUpdatedAtColumn types.Bool `tfsdk:"include_database_updated_at_column"`
-	OneTopicPerSchema              types.Bool `tfsdk:"one_topic_per_schema"`
+	DataPlaneName                  types.String `tfsdk:"data_plane_name"`
+	DropDeletedColumns             types.Bool   `tfsdk:"drop_deleted_columns"`
+	SoftDeleteRows                 types.Bool   `tfsdk:"soft_delete_rows"`
+	IncludeArtieUpdatedAtColumn    types.Bool   `tfsdk:"include_artie_updated_at_column"`
+	IncludeDatabaseUpdatedAtColumn types.Bool   `tfsdk:"include_database_updated_at_column"`
+	OneTopicPerSchema              types.Bool   `tfsdk:"one_topic_per_schema"`
 }
 
 func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeployment, diag.Diagnostics) {
@@ -52,12 +53,14 @@ func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeploym
 	}
 
 	return artieclient.BaseDeployment{
-		Name:                           d.Name.ValueString(),
-		Source:                         apiSource,
-		DestinationUUID:                destinationUUID,
-		DestinationConfig:              d.DestinationConfig.ToAPIModel(),
-		SSHTunnelUUID:                  sshTunnelUUID,
-		SnowflakeEcoScheduleUUID:       snowflakeEcoScheduleUUID,
+		Name:                     d.Name.ValueString(),
+		Source:                   apiSource,
+		DestinationUUID:          destinationUUID,
+		DestinationConfig:        d.DestinationConfig.ToAPIModel(),
+		SSHTunnelUUID:            sshTunnelUUID,
+		SnowflakeEcoScheduleUUID: snowflakeEcoScheduleUUID,
+		// Advanced settings:
+		DataPlaneName:                  d.DataPlaneName.ValueStringPointer(),
 		DropDeletedColumns:             d.DropDeletedColumns.ValueBoolPointer(),
 		EnableSoftDelete:               d.SoftDeleteRows.ValueBoolPointer(),
 		IncludeArtieUpdatedAtColumn:    d.IncludeArtieUpdatedAtColumn.ValueBoolPointer(),
@@ -93,14 +96,17 @@ func DeploymentFromAPIModel(ctx context.Context, apiModel artieclient.Deployment
 
 	destinationConfig := DeploymentDestinationConfigFromAPIModel(apiModel.DestinationConfig)
 	return Deployment{
-		UUID:                           types.StringValue(apiModel.UUID.String()),
-		Name:                           types.StringValue(apiModel.Name),
-		Status:                         types.StringValue(apiModel.Status),
-		Source:                         &source,
-		DestinationUUID:                optionalUUIDToStringValue(apiModel.DestinationUUID),
-		DestinationConfig:              &destinationConfig,
-		SSHTunnelUUID:                  optionalUUIDToStringValue(apiModel.SSHTunnelUUID),
-		SnowflakeEcoScheduleUUID:       optionalUUIDToStringValue(apiModel.SnowflakeEcoScheduleUUID),
+		UUID:                     types.StringValue(apiModel.UUID.String()),
+		Name:                     types.StringValue(apiModel.Name),
+		Status:                   types.StringValue(apiModel.Status),
+		Source:                   &source,
+		DestinationUUID:          optionalUUIDToStringValue(apiModel.DestinationUUID),
+		DestinationConfig:        &destinationConfig,
+		SSHTunnelUUID:            optionalUUIDToStringValue(apiModel.SSHTunnelUUID),
+		SnowflakeEcoScheduleUUID: optionalUUIDToStringValue(apiModel.SnowflakeEcoScheduleUUID),
+
+		// Advanced settings:
+		DataPlaneName:                  types.StringPointerValue(apiModel.DataPlaneName),
 		DropDeletedColumns:             types.BoolPointerValue(apiModel.DropDeletedColumns),
 		SoftDeleteRows:                 types.BoolPointerValue(apiModel.EnableSoftDelete),
 		IncludeArtieUpdatedAtColumn:    types.BoolPointerValue(apiModel.IncludeArtieUpdatedAtColumn),

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -18,14 +18,14 @@ type Deployment struct {
 	DestinationConfig        *DeploymentDestinationConfig `tfsdk:"destination_config"`
 	SSHTunnelUUID            types.String                 `tfsdk:"ssh_tunnel_uuid"`
 	SnowflakeEcoScheduleUUID types.String                 `tfsdk:"snowflake_eco_schedule_uuid"`
+	DataPlaneName            types.String                 `tfsdk:"data_plane_name"`
 
 	// Advanced settings
-	DataPlaneName                  types.String `tfsdk:"data_plane_name"`
-	DropDeletedColumns             types.Bool   `tfsdk:"drop_deleted_columns"`
-	SoftDeleteRows                 types.Bool   `tfsdk:"soft_delete_rows"`
-	IncludeArtieUpdatedAtColumn    types.Bool   `tfsdk:"include_artie_updated_at_column"`
-	IncludeDatabaseUpdatedAtColumn types.Bool   `tfsdk:"include_database_updated_at_column"`
-	OneTopicPerSchema              types.Bool   `tfsdk:"one_topic_per_schema"`
+	DropDeletedColumns             types.Bool `tfsdk:"drop_deleted_columns"`
+	SoftDeleteRows                 types.Bool `tfsdk:"soft_delete_rows"`
+	IncludeArtieUpdatedAtColumn    types.Bool `tfsdk:"include_artie_updated_at_column"`
+	IncludeDatabaseUpdatedAtColumn types.Bool `tfsdk:"include_database_updated_at_column"`
+	OneTopicPerSchema              types.Bool `tfsdk:"one_topic_per_schema"`
 }
 
 func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeployment, diag.Diagnostics) {


### PR DESCRIPTION
This allows customers to specify which data plane to deploy this into.