### PR TITLE
Fix optional fields (use computed + planmodifier + no default)

### DIFF
--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -88,7 +88,7 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 						MarkdownDescription: "This should be filled out if the source type is `mysql`.",
 						Attributes: map[string]schema.Attribute{
 							"host":          schema.StringAttribute{Required: true, MarkdownDescription: "The hostname of the MySQL database. This must point to the primary host, not a read replica."},
-							"snapshot_host": schema.StringAttribute{Optional: true, MarkdownDescription: "The hostname of the MySQL database that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
+							"snapshot_host": schema.StringAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}, MarkdownDescription: "The hostname of the MySQL database that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
 							"port": schema.Int32Attribute{
 								Required:            true,
 								MarkdownDescription: "The default port for MySQL is 3306.",
@@ -106,7 +106,7 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 						MarkdownDescription: "This should be filled out if the source type is `mssql`.",
 						Attributes: map[string]schema.Attribute{
 							"host":          schema.StringAttribute{Required: true, MarkdownDescription: "The hostname of the Microsoft SQL Server. This must point to the primary host, not a read replica."},
-							"snapshot_host": schema.StringAttribute{Optional: true, MarkdownDescription: "The hostname of the Microsoft SQL Server that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
+							"snapshot_host": schema.StringAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}, MarkdownDescription: "The hostname of the Microsoft SQL Server that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
 							"port": schema.Int32Attribute{
 								Required:            true,
 								MarkdownDescription: "The default port for Microsoft SQL Server is 1433.",
@@ -124,7 +124,7 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 						MarkdownDescription: "This should be filled out if the source type is `oracle`.",
 						Attributes: map[string]schema.Attribute{
 							"host":          schema.StringAttribute{Required: true, MarkdownDescription: "The hostname of the Oracle database. This must point to the primary host, not a read replica. This database must also have `ARCHIVELOG` mode and supplemental logging enabled."},
-							"snapshot_host": schema.StringAttribute{Optional: true, MarkdownDescription: "The hostname of the Oracle database that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
+							"snapshot_host": schema.StringAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}, MarkdownDescription: "The hostname of the Oracle database that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
 							"port": schema.Int32Attribute{
 								Required:            true,
 								MarkdownDescription: "The default port for Oracle is 1521.",
@@ -143,7 +143,7 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 						MarkdownDescription: "This should be filled out if the source type is `postgresql`.",
 						Attributes: map[string]schema.Attribute{
 							"host":          schema.StringAttribute{Required: true, MarkdownDescription: "The hostname of the PostgreSQL database. This must point to the primary host, not a read replica. This database must also have its `WAL_LEVEL` set to `logical`."},
-							"snapshot_host": schema.StringAttribute{Optional: true, MarkdownDescription: "The hostname of the PostgreSQL database that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
+							"snapshot_host": schema.StringAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}, MarkdownDescription: "The hostname of the PostgreSQL database that we should use to snapshot the database. This can be a read replica, if not provided, we will use the `host` value."},
 							"port": schema.Int32Attribute{
 								Required:            true,
 								MarkdownDescription: "The default port for PostgreSQL is 5432.",
@@ -244,7 +244,6 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 				MarkdownDescription: "The name of the data plane to use for this deployment. If this is not set, we will use the default data plane for your account. To see the full list of supported data planes on your account, click on `Create deployment`",
 				Optional:            true,
 				Computed:            true,
-				Default:             stringdefault.StaticString(""),
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"drop_deleted_columns":               schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()}, MarkdownDescription: "If set to true, when a column is dropped from the source it will also be dropped in the destination."},


### PR DESCRIPTION
The new fields for `snapshot_host` and `data_plane_name` should be optional in the config and use whatever existing value the dashboard api returns if they aren't specified. To achieve this, the field needs the following settings:
- Optional: true
- Computed: true
- Plan modifiers: use state for unknown
- No default value