### PR TITLE
Flush Config to use `types.Object`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
+	github.com/stretchr/testify v1.8.3
 )
 
 require (
@@ -22,6 +23,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.8.1 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/cli v1.1.7 // indirect
@@ -50,6 +52,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"terraform-provider-artie/internal/artieclient"
 )
@@ -22,14 +23,14 @@ type Deployment struct {
 	DataPlaneName            types.String                 `tfsdk:"data_plane_name"`
 
 	// Advanced settings
-	FlushConfig                    *DeploymentFlushConfig `tfsdk:"flush_config"`
-	DropDeletedColumns             types.Bool             `tfsdk:"drop_deleted_columns"`
-	SoftDeleteRows                 types.Bool             `tfsdk:"soft_delete_rows"`
-	IncludeArtieUpdatedAtColumn    types.Bool             `tfsdk:"include_artie_updated_at_column"`
-	IncludeDatabaseUpdatedAtColumn types.Bool             `tfsdk:"include_database_updated_at_column"`
-	OneTopicPerSchema              types.Bool             `tfsdk:"one_topic_per_schema"`
-	PublicationNameOverride        types.String           `tfsdk:"postgres_publication_name_override"`
-	ReplicationSlotOverride        types.String           `tfsdk:"postgres_replication_slot_override"`
+	FlushConfig                    types.Object `tfsdk:"flush_config"`
+	DropDeletedColumns             types.Bool   `tfsdk:"drop_deleted_columns"`
+	SoftDeleteRows                 types.Bool   `tfsdk:"soft_delete_rows"`
+	IncludeArtieUpdatedAtColumn    types.Bool   `tfsdk:"include_artie_updated_at_column"`
+	IncludeDatabaseUpdatedAtColumn types.Bool   `tfsdk:"include_database_updated_at_column"`
+	OneTopicPerSchema              types.Bool   `tfsdk:"one_topic_per_schema"`
+	PublicationNameOverride        types.String `tfsdk:"postgres_publication_name_override"`
+	ReplicationSlotOverride        types.String `tfsdk:"postgres_replication_slot_override"`
 }
 
 type DeploymentFlushConfig struct {
@@ -68,6 +69,17 @@ func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeploym
 		return artieclient.BaseDeployment{}, diags
 	}
 
+	var flushConfig *DeploymentFlushConfig
+	flushConfigDiags := d.FlushConfig.As(ctx, &flushConfig, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    true,
+		UnhandledUnknownAsEmpty: true,
+	})
+
+	diags.Append(flushConfigDiags...)
+	if diags.HasError() {
+		return artieclient.BaseDeployment{}, diags
+	}
+
 	return artieclient.BaseDeployment{
 		Name:                     d.Name.ValueString(),
 		Source:                   apiSource,
@@ -77,7 +89,7 @@ func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeploym
 		SnowflakeEcoScheduleUUID: snowflakeEcoScheduleUUID,
 		DataPlaneName:            d.DataPlaneName.ValueString(),
 		// Advanced settings:
-		FlushConfig:                    d.FlushConfig.ToAPIModel(),
+		FlushConfig:                    flushConfig.ToAPIModel(),
 		DropDeletedColumns:             d.DropDeletedColumns.ValueBoolPointer(),
 		EnableSoftDelete:               d.SoftDeleteRows.ValueBoolPointer(),
 		IncludeArtieUpdatedAtColumn:    d.IncludeArtieUpdatedAtColumn.ValueBoolPointer(),
@@ -115,9 +127,14 @@ func DeploymentFromAPIModel(ctx context.Context, apiModel artieclient.Deployment
 
 	destinationConfig := DeploymentDestinationConfigFromAPIModel(apiModel.DestinationConfig)
 
-	var flushConfig *DeploymentFlushConfig
+	var flushConfig types.Object
 	if apiModel.FlushConfig != nil {
-		flushConfig = DeploymentFlushConfigFromAPIModel(*apiModel.FlushConfig)
+		flushConfigObj, flushConfigDiags := DeploymentFlushConfigFromAPIModel(ctx, *apiModel.FlushConfig)
+		diags.Append(flushConfigDiags...)
+		if diags.HasError() {
+			return Deployment{}, diags
+		}
+		flushConfig = flushConfigObj
 	}
 
 	return Deployment{
@@ -153,7 +170,12 @@ type DeploymentDestinationConfig struct {
 	Folder                types.String `tfsdk:"folder"`
 }
 
-func (d DeploymentFlushConfig) ToAPIModel() *artieclient.FlushConfig {
+func (d *DeploymentFlushConfig) ToAPIModel() *artieclient.FlushConfig {
+	if d == nil {
+		// Support unknown.
+		return nil
+	}
+
 	return &artieclient.FlushConfig{
 		FlushIntervalSeconds: d.FlushIntervalSeconds.ValueInt64(),
 		BufferRows:           d.BufferRows.ValueInt64(),
@@ -185,10 +207,10 @@ func DeploymentDestinationConfigFromAPIModel(apiModel artieclient.DestinationCon
 	}
 }
 
-func DeploymentFlushConfigFromAPIModel(apiModel artieclient.FlushConfig) *DeploymentFlushConfig {
-	return &DeploymentFlushConfig{
+func DeploymentFlushConfigFromAPIModel(ctx context.Context, apiModel artieclient.FlushConfig) (types.Object, diag.Diagnostics) {
+	return types.ObjectValueFrom(ctx, flushAttrTypes, DeploymentFlushConfig{
 		FlushIntervalSeconds: types.Int64Value(apiModel.FlushIntervalSeconds),
 		BufferRows:           types.Int64Value(apiModel.BufferRows),
 		FlushSizeKB:          types.Int64Value(apiModel.FlushSizeKB),
-	}
+	})
 }

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -3,6 +3,7 @@ package tfmodels
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -29,6 +30,18 @@ type Deployment struct {
 	OneTopicPerSchema              types.Bool             `tfsdk:"one_topic_per_schema"`
 	PublicationNameOverride        types.String           `tfsdk:"postgres_publication_name_override"`
 	ReplicationSlotOverride        types.String           `tfsdk:"postgres_replication_slot_override"`
+}
+
+type DeploymentFlushConfig struct {
+	FlushIntervalSeconds types.Int64 `tfsdk:"flush_interval_seconds"`
+	BufferRows           types.Int64 `tfsdk:"buffer_rows"`
+	FlushSizeKB          types.Int64 `tfsdk:"flush_size_kb"`
+}
+
+var flushAttrTypes = map[string]attr.Type{
+	"flush_interval_seconds": types.Int64Type,
+	"buffer_rows":            types.Int64Type,
+	"flush_size_kb":          types.Int64Type,
 }
 
 func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeployment, diag.Diagnostics) {
@@ -138,12 +151,6 @@ type DeploymentDestinationConfig struct {
 	SchemaNamePrefix      types.String `tfsdk:"schema_name_prefix"`
 	Bucket                types.String `tfsdk:"bucket"`
 	Folder                types.String `tfsdk:"folder"`
-}
-
-type DeploymentFlushConfig struct {
-	FlushIntervalSeconds types.Int64 `tfsdk:"flush_interval_seconds"`
-	BufferRows           types.Int64 `tfsdk:"buffer_rows"`
-	FlushSizeKB          types.Int64 `tfsdk:"flush_size_kb"`
 }
 
 func (d DeploymentFlushConfig) ToAPIModel() *artieclient.FlushConfig {

--- a/internal/provider/tfmodels/deployment.go
+++ b/internal/provider/tfmodels/deployment.go
@@ -70,14 +70,16 @@ func (d Deployment) ToAPIBaseModel(ctx context.Context) (artieclient.BaseDeploym
 	}
 
 	var flushConfig *DeploymentFlushConfig
-	flushConfigDiags := d.FlushConfig.As(ctx, &flushConfig, basetypes.ObjectAsOptions{
-		UnhandledNullAsEmpty:    true,
-		UnhandledUnknownAsEmpty: true,
-	})
+	if !d.FlushConfig.IsNull() && !d.FlushConfig.IsUnknown() {
+		flushConfigDiags := d.FlushConfig.As(ctx, &flushConfig, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    true,
+			UnhandledUnknownAsEmpty: true,
+		})
 
-	diags.Append(flushConfigDiags...)
-	if diags.HasError() {
-		return artieclient.BaseDeployment{}, diags
+		diags.Append(flushConfigDiags...)
+		if diags.HasError() {
+			return artieclient.BaseDeployment{}, diags
+		}
 	}
 
 	return artieclient.BaseDeployment{

--- a/internal/provider/tfmodels/deployment_test.go
+++ b/internal/provider/tfmodels/deployment_test.go
@@ -31,6 +31,8 @@ func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
 			"flush_size_kb":          types.Int64Value(1000),
 		})
 
+		assert.False(t, diags.HasError(), "failed to create flush object")
+
 		flushConfig, diags := buildFlushConfig(t.Context(), flushObject)
 		assert.False(t, diags.HasError(), "failed to create flush config")
 		assert.NotNil(t, flushConfig)

--- a/internal/provider/tfmodels/deployment_test.go
+++ b/internal/provider/tfmodels/deployment_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
 	{
-		// nil object
+		// zero object
 		var object types.Object
 		flushConfig, diags := buildFlushConfig(t.Context(), object)
 		assert.False(t, diags.HasError(), "expected no error when creating nil object")

--- a/internal/provider/tfmodels/deployment_test.go
+++ b/internal/provider/tfmodels/deployment_test.go
@@ -10,27 +10,42 @@ import (
 )
 
 func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
-	flushObject, diags := types.ObjectValue(flushAttrTypes, map[string]attr.Value{
-		"flush_interval_seconds": types.Int64Value(100),
-		"buffer_rows":            types.Int64Value(5000),
-		"flush_size_kb":          types.Int64Value(1000),
-	})
+	{
+		// nil object
+		var object types.Object
+		var flushConfig *DeploymentFlushConfig
+		diags := object.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    true,
+			UnhandledUnknownAsEmpty: true,
+		})
 
-	assert.False(t, diags.HasError(), "failed to create flush config")
+		assert.False(t, diags.HasError(), "expected no error when creating nil object")
+		assert.Nil(t, flushConfig)
+	}
+	{
+		// object is set
+		flushObject, diags := types.ObjectValue(flushAttrTypes, map[string]attr.Value{
+			"flush_interval_seconds": types.Int64Value(100),
+			"buffer_rows":            types.Int64Value(5000),
+			"flush_size_kb":          types.Int64Value(1000),
+		})
 
-	var flushConfig *DeploymentFlushConfig
-	flushConfigDiags := flushObject.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
-		UnhandledNullAsEmpty:    true,
-		UnhandledUnknownAsEmpty: true,
-	})
+		assert.False(t, diags.HasError(), "failed to create flush config")
 
-	assert.False(t, flushConfigDiags.HasError(), "failed to convert flush config")
-	assert.Equal(t, flushConfig.FlushIntervalSeconds.ValueInt64(), int64(100))
-	assert.Equal(t, flushConfig.BufferRows.ValueInt64(), int64(5000))
-	assert.Equal(t, flushConfig.FlushSizeKB.ValueInt64(), int64(1000))
+		var flushConfig *DeploymentFlushConfig
+		flushConfigDiags := flushObject.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    true,
+			UnhandledUnknownAsEmpty: true,
+		})
 
-	apiFlushConfig := flushConfig.ToAPIModel()
-	assert.Equal(t, apiFlushConfig.FlushIntervalSeconds, int64(100))
-	assert.Equal(t, apiFlushConfig.BufferRows, int64(5000))
-	assert.Equal(t, apiFlushConfig.FlushSizeKB, int64(1000))
+		assert.False(t, flushConfigDiags.HasError(), "failed to convert flush config")
+		assert.Equal(t, flushConfig.FlushIntervalSeconds.ValueInt64(), int64(100))
+		assert.Equal(t, flushConfig.BufferRows.ValueInt64(), int64(5000))
+		assert.Equal(t, flushConfig.FlushSizeKB.ValueInt64(), int64(1000))
+
+		apiFlushConfig := flushConfig.ToAPIModel()
+		assert.Equal(t, apiFlushConfig.FlushIntervalSeconds, int64(100))
+		assert.Equal(t, apiFlushConfig.BufferRows, int64(5000))
+		assert.Equal(t, apiFlushConfig.FlushSizeKB, int64(1000))
+	}
 }

--- a/internal/provider/tfmodels/deployment_test.go
+++ b/internal/provider/tfmodels/deployment_test.go
@@ -1,0 +1,36 @@
+package tfmodels
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
+	flushObject, diags := types.ObjectValue(flushAttrTypes, map[string]attr.Value{
+		"flush_interval_seconds": types.Int64Value(100),
+		"buffer_rows":            types.Int64Value(5000),
+		"flush_size_kb":          types.Int64Value(1000),
+	})
+
+	assert.False(t, diags.HasError(), "failed to create flush config")
+
+	var flushConfig *DeploymentFlushConfig
+	flushConfigDiags := flushObject.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    true,
+		UnhandledUnknownAsEmpty: true,
+	})
+
+	assert.False(t, flushConfigDiags.HasError(), "failed to convert flush config")
+	assert.Equal(t, flushConfig.FlushIntervalSeconds.ValueInt64(), int64(100))
+	assert.Equal(t, flushConfig.BufferRows.ValueInt64(), int64(5000))
+	assert.Equal(t, flushConfig.FlushSizeKB.ValueInt64(), int64(1000))
+
+	apiFlushConfig := flushConfig.ToAPIModel()
+	assert.Equal(t, apiFlushConfig.FlushIntervalSeconds, int64(100))
+	assert.Equal(t, apiFlushConfig.BufferRows, int64(5000))
+	assert.Equal(t, apiFlushConfig.FlushSizeKB, int64(1000))
+}

--- a/internal/provider/tfmodels/deployment_test.go
+++ b/internal/provider/tfmodels/deployment_test.go
@@ -17,6 +17,13 @@ func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
 		assert.Nil(t, flushConfig)
 	}
 	{
+		// null object
+		nullObject := types.ObjectNull(flushAttrTypes)
+		flushConfig, diags := buildFlushConfig(t.Context(), nullObject)
+		assert.False(t, diags.HasError(), "expected no error when creating null object")
+		assert.Nil(t, flushConfig)
+	}
+	{
 		// unknown object
 		unknownObject := types.ObjectUnknown(flushAttrTypes)
 		flushConfig, diags := buildFlushConfig(t.Context(), unknownObject)

--- a/internal/provider/tfmodels/deployment_test.go
+++ b/internal/provider/tfmodels/deployment_test.go
@@ -23,6 +23,18 @@ func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
 		assert.Nil(t, flushConfig)
 	}
 	{
+		// unknown object
+		unknownObject := types.ObjectUnknown(flushAttrTypes)
+		var flushConfig *DeploymentFlushConfig
+		diags := unknownObject.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    true,
+			UnhandledUnknownAsEmpty: true,
+		})
+
+		assert.False(t, diags.HasError(), "expected no error when creating unknown object")
+		assert.Nil(t, flushConfig)
+	}
+	{
 		// object is set
 		flushObject, diags := types.ObjectValue(flushAttrTypes, map[string]attr.Value{
 			"flush_interval_seconds": types.Int64Value(100),

--- a/internal/provider/tfmodels/deployment_test.go
+++ b/internal/provider/tfmodels/deployment_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,24 +12,14 @@ func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
 	{
 		// nil object
 		var object types.Object
-		var flushConfig *DeploymentFlushConfig
-		diags := object.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
-			UnhandledNullAsEmpty:    true,
-			UnhandledUnknownAsEmpty: true,
-		})
-
+		flushConfig, diags := buildFlushConfig(t.Context(), object)
 		assert.False(t, diags.HasError(), "expected no error when creating nil object")
 		assert.Nil(t, flushConfig)
 	}
 	{
 		// unknown object
 		unknownObject := types.ObjectUnknown(flushAttrTypes)
-		var flushConfig *DeploymentFlushConfig
-		diags := unknownObject.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
-			UnhandledNullAsEmpty:    true,
-			UnhandledUnknownAsEmpty: true,
-		})
-
+		flushConfig, diags := buildFlushConfig(t.Context(), unknownObject)
 		assert.False(t, diags.HasError(), "expected no error when creating unknown object")
 		assert.Nil(t, flushConfig)
 	}
@@ -42,15 +31,10 @@ func TestDeploymentFlushConfigFromAPIModel(t *testing.T) {
 			"flush_size_kb":          types.Int64Value(1000),
 		})
 
+		flushConfig, diags := buildFlushConfig(t.Context(), flushObject)
 		assert.False(t, diags.HasError(), "failed to create flush config")
+		assert.NotNil(t, flushConfig)
 
-		var flushConfig *DeploymentFlushConfig
-		flushConfigDiags := flushObject.As(t.Context(), &flushConfig, basetypes.ObjectAsOptions{
-			UnhandledNullAsEmpty:    true,
-			UnhandledUnknownAsEmpty: true,
-		})
-
-		assert.False(t, flushConfigDiags.HasError(), "failed to convert flush config")
 		assert.Equal(t, flushConfig.FlushIntervalSeconds.ValueInt64(), int64(100))
 		assert.Equal(t, flushConfig.BufferRows.ValueInt64(), int64(5000))
 		assert.Equal(t, flushConfig.FlushSizeKB.ValueInt64(), int64(1000))


### PR DESCRIPTION
Using `types.Object` instead of our custom type so that it supports unknown values.

I also added tests around this