### PR TITLE
Adding a semaphore around pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module terraform-provider-artie
 
 go 1.24.0
+
 require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
@@ -8,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.11.0
 )
 
 require (

--- a/internal/artieclient/client.go
+++ b/internal/artieclient/client.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-var ErrNotFound = fmt.Errorf("artie-client: not found")
-
 type HttpError struct {
 	StatusCode int
 	message    string
@@ -44,7 +42,7 @@ func New(endpoint string, apiKey string, version string) (Client, error) {
 
 func buildError(resp *http.Response) error {
 	if resp.StatusCode == http.StatusNotFound {
-		return ErrNotFound
+		return fmt.Errorf("artie-client: not found, request: %q, method: %q", resp.Request.URL.String(), resp.Request.Method)
 	} else if resp.StatusCode >= 400 && resp.StatusCode < 500 { // Client errors
 		type errorBody struct {
 			ErrorMsg string `json:"error"`


### PR DESCRIPTION
This way, we can control the parallelism for mutating pipeline resources and not run into timeouts that arise from trying to acquire a git lock