### PR TITLE
Validate & deploy shared source readers after creating/updating

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,34 +54,47 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
-  # Run acceptance tests in a matrix with Terraform CLI versions
-  test:
-    name: Terraform Provider Acceptance Tests
-    needs: build
+  # Run unit tests
+  unit-test:
+    name: Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
           cache: true
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-      - run: go mod download
-      - env:
-          TF_ACC: "1"
-        run: go test -v -cover ./internal/provider/
-        timeout-minutes: 10
+      - run: go test -v -cover ./...
+
+  # Run acceptance tests in a matrix with Terraform CLI versions
+  # test:
+  #   name: Terraform Provider Acceptance Tests
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       # list whatever Terraform versions here you would like to support
+  #       terraform:
+  #         - '1.0.*'
+  #         - '1.1.*'
+  #         - '1.2.*'
+  #         - '1.3.*'
+  #         - '1.4.*'
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #     - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+  #       with:
+  #         go-version-file: 'go.mod'
+  #         cache: true
+  #     - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+  #       with:
+  #         terraform_version: ${{ matrix.terraform }}
+  #         terraform_wrapper: false
+  #     - run: go mod download
+  #     - env:
+  #         TF_ACC: "1"
+  #       run: go test -v -cover ./internal/provider/
+  #       timeout-minutes: 10

--- a/internal/artieclient/source_reader.go
+++ b/internal/artieclient/source_reader.go
@@ -2,7 +2,6 @@ package artieclient
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -81,20 +80,12 @@ func (sc SourceReaderClient) Delete(ctx context.Context, sourceReaderUUID string
 	return err
 }
 
-func (sc SourceReaderClient) Validate(ctx context.Context, sourceReader BaseSourceReader) error {
-	path, err := url.JoinPath(sc.basePath(), "validate")
+func (sc SourceReaderClient) Deploy(ctx context.Context, sourceReaderUUID string) error {
+	path, err := url.JoinPath(sc.basePath(), sourceReaderUUID, "deploy")
 	if err != nil {
 		return err
 	}
 
-	response, err := makeRequest[validationResponse](ctx, sc.client, http.MethodPost, path, sourceReader)
-	if err != nil {
-		return err
-	}
-
-	if response.Error != "" {
-		return fmt.Errorf("source reader validation failed: %s", response.Error)
-	}
-
-	return nil
+	_, err = makeRequest[any](ctx, sc.client, http.MethodPost, path, nil)
+	return err
 }

--- a/internal/provider/source_reader_resource_test.go
+++ b/internal/provider/source_reader_resource_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -31,7 +30,7 @@ func TestSourceReaderResource_ValidateConfig(t *testing.T) {
 			IsShared:      types.BoolValue(false),
 		}
 
-		diags := validateSourceReaderConfig(context.Background(), config)
+		diags := validateSourceReaderConfig(t.Context(), config)
 		assert.False(t, diags.HasError())
 	}
 	{
@@ -41,7 +40,7 @@ func TestSourceReaderResource_ValidateConfig(t *testing.T) {
 			BackfillBatchSize: types.Int64Value(60000),
 		}
 
-		diags := validateSourceReaderConfig(context.Background(), config)
+		diags := validateSourceReaderConfig(t.Context(), config)
 		assert.True(t, diags.HasError())
 		assert.Contains(t, diags.Errors()[0].Detail(), "The maximum allowed value for `backfill_batch_size` is 50,000.")
 	}
@@ -51,7 +50,7 @@ func TestSourceReaderResource_ValidateConfig(t *testing.T) {
 			IsShared:      types.BoolValue(true),
 		}
 
-		diags := validateSourceReaderConfig(context.Background(), config)
+		diags := validateSourceReaderConfig(t.Context(), config)
 		assert.True(t, diags.HasError())
 		assert.Contains(t, diags.Errors()[0].Detail(), "You must specify a `tables` block if `is_shared` is set to true.")
 	}
@@ -77,7 +76,7 @@ func TestSourceReaderResource_ValidateConfig(t *testing.T) {
 			),
 		}
 
-		diags := validateSourceReaderConfig(context.Background(), config)
+		diags := validateSourceReaderConfig(t.Context(), config)
 		assert.True(t, diags.HasError())
 		assert.Contains(t, diags.Errors()[0].Detail(), "You should not specify a `tables` block if `is_shared` is set to false.")
 	}
@@ -103,7 +102,7 @@ func TestSourceReaderResource_ValidateConfig(t *testing.T) {
 			),
 		}
 
-		diags := validateSourceReaderConfig(context.Background(), config)
+		diags := validateSourceReaderConfig(t.Context(), config)
 		assert.True(t, diags.HasError())
 		assert.Contains(t, diags.Errors()[0].Detail(), "Table key \"wrong_key\" should be \"public.test_table\" instead.")
 	}
@@ -129,7 +128,7 @@ func TestSourceReaderResource_ValidateConfig(t *testing.T) {
 			),
 		}
 
-		diags := validateSourceReaderConfig(context.Background(), config)
+		diags := validateSourceReaderConfig(t.Context(), config)
 		assert.True(t, diags.HasError())
 		assert.Contains(t, diags.Errors()[0].Detail(), "You can only use one of `columns_to_include` and `columns_to_exclude` within a source reader.")
 	}


### PR DESCRIPTION
Same idea as https://github.com/artie-labs/terraform-provider-artie/pull/174

Also added more validation for the tables config on source readers.