### PR TITLE
Move dynamo config type out of deprecated file

### DIFF
--- a/internal/provider/tfmodels/connector.go
+++ b/internal/provider/tfmodels/connector.go
@@ -156,6 +156,39 @@ func BigQuerySharedConfigFromAPIModel(apiModel artieclient.ConnectorConfig) *Big
 	}
 }
 
+type DynamoDBConfig struct {
+	StreamArn          types.String `tfsdk:"stream_arn"`
+	AwsAccessKeyID     types.String `tfsdk:"access_key_id"`
+	AwsSecretAccessKey types.String `tfsdk:"secret_access_key"`
+	Backfill           types.Bool   `tfsdk:"backfill"`
+	BackfillBucket     types.String `tfsdk:"backfill_bucket"`
+	BackfillFolder     types.String `tfsdk:"backfill_folder"`
+}
+
+func (d DynamoDBConfig) ToAPIModel() artieclient.ConnectorConfig {
+	return artieclient.ConnectorConfig{
+		DynamoStreamArn:    d.StreamArn.ValueString(),
+		AWSAccessKeyID:     d.AwsAccessKeyID.ValueString(),
+		AWSSecretAccessKey: d.AwsSecretAccessKey.ValueString(),
+		DynamoSnapshotConfig: artieclient.DynamoDBSnapshotConfig{
+			Enabled:        d.Backfill.ValueBool(),
+			Bucket:         d.BackfillBucket.ValueString(),
+			OptionalFolder: d.BackfillFolder.ValueString(),
+		},
+	}
+}
+
+func DynamoDBConfigFromAPIModel(apiDynamoCfg artieclient.ConnectorConfig) *DynamoDBConfig {
+	return &DynamoDBConfig{
+		StreamArn:          types.StringValue(apiDynamoCfg.DynamoStreamArn),
+		AwsAccessKeyID:     types.StringValue(apiDynamoCfg.AWSAccessKeyID),
+		AwsSecretAccessKey: types.StringValue(apiDynamoCfg.AWSSecretAccessKey),
+		Backfill:           types.BoolValue(apiDynamoCfg.DynamoSnapshotConfig.Enabled),
+		BackfillBucket:     types.StringValue(apiDynamoCfg.DynamoSnapshotConfig.Bucket),
+		BackfillFolder:     types.StringValue(apiDynamoCfg.DynamoSnapshotConfig.OptionalFolder),
+	}
+}
+
 type MongoDBSharedConfig struct {
 	Host     types.String `tfsdk:"host"`
 	Username types.String `tfsdk:"username"`

--- a/internal/provider/tfmodels/deployment_source.go
+++ b/internal/provider/tfmodels/deployment_source.go
@@ -107,15 +107,6 @@ func SourceFromAPIModel(ctx context.Context, apiModel artieclient.Source) (Sourc
 	return source, diags
 }
 
-type DynamoDBConfig struct {
-	StreamArn          types.String `tfsdk:"stream_arn"`
-	AwsAccessKeyID     types.String `tfsdk:"access_key_id"`
-	AwsSecretAccessKey types.String `tfsdk:"secret_access_key"`
-	Backfill           types.Bool   `tfsdk:"backfill"`
-	BackfillBucket     types.String `tfsdk:"backfill_bucket"`
-	BackfillFolder     types.String `tfsdk:"backfill_folder"`
-}
-
 func (d DynamoDBConfig) ToAPISourceConfigModel() artieclient.SourceConfig {
 	return artieclient.SourceConfig{
 		DynamoDB: &artieclient.DynamoDBConfig{
@@ -131,19 +122,6 @@ func (d DynamoDBConfig) ToAPISourceConfigModel() artieclient.SourceConfig {
 	}
 }
 
-func (d DynamoDBConfig) ToAPIModel() artieclient.ConnectorConfig {
-	return artieclient.ConnectorConfig{
-		DynamoStreamArn:    d.StreamArn.ValueString(),
-		AWSAccessKeyID:     d.AwsAccessKeyID.ValueString(),
-		AWSSecretAccessKey: d.AwsSecretAccessKey.ValueString(),
-		DynamoSnapshotConfig: artieclient.DynamoDBSnapshotConfig{
-			Enabled:        d.Backfill.ValueBool(),
-			Bucket:         d.BackfillBucket.ValueString(),
-			OptionalFolder: d.BackfillFolder.ValueString(),
-		},
-	}
-}
-
 func DynamoDBConfigFromAPISourceConfigModel(apiDynamoCfg artieclient.DynamoDBConfig) *DynamoDBConfig {
 	return &DynamoDBConfig{
 		StreamArn:          types.StringValue(apiDynamoCfg.StreamsArn),
@@ -152,17 +130,6 @@ func DynamoDBConfigFromAPISourceConfigModel(apiDynamoCfg artieclient.DynamoDBCon
 		Backfill:           types.BoolValue(apiDynamoCfg.SnapshotConfig.Enabled),
 		BackfillBucket:     types.StringValue(apiDynamoCfg.SnapshotConfig.Bucket),
 		BackfillFolder:     types.StringValue(apiDynamoCfg.SnapshotConfig.OptionalFolder),
-	}
-}
-
-func DynamoDBConfigFromAPIModel(apiDynamoCfg artieclient.ConnectorConfig) *DynamoDBConfig {
-	return &DynamoDBConfig{
-		StreamArn:          types.StringValue(apiDynamoCfg.DynamoStreamArn),
-		AwsAccessKeyID:     types.StringValue(apiDynamoCfg.AWSAccessKeyID),
-		AwsSecretAccessKey: types.StringValue(apiDynamoCfg.AWSSecretAccessKey),
-		Backfill:           types.BoolValue(apiDynamoCfg.DynamoSnapshotConfig.Enabled),
-		BackfillBucket:     types.StringValue(apiDynamoCfg.DynamoSnapshotConfig.Bucket),
-		BackfillFolder:     types.StringValue(apiDynamoCfg.DynamoSnapshotConfig.OptionalFolder),
 	}
 }
 


### PR DESCRIPTION
This is the only source config type that's used by both the Connector resource and the deprecated Deployment resource - moving it into the connector file in preparation for removing the other one.