### PR TITLE
Add import instructions to the rest of the resources

### DIFF
--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -180,3 +180,20 @@ Optional:
 
 - `password` (String, Sensitive) The password for the service account we should use to connect to Snowflake. Either `password` or `private_key` must be provided.
 - `private_key` (String, Sensitive) The private key for the service account we should use to connect to Snowflake. Either `password` or `private_key` must be provided.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Import a connector by using its UUID, which you can find by:
+# 1. Go to the pipeline overview page in the Artie UI
+# 2. Click on the "View UUIDs" button to see all related resource UUIDs
+terraform import artie_connector.my_connector <connector_uuid>
+
+# Then print the state and copy it into your terraform config file
+# (be sure to remove all read-only fields, like `uuid`):
+terraform state show artie_connector.my_connector
+```

--- a/docs/resources/source_reader.md
+++ b/docs/resources/source_reader.md
@@ -84,3 +84,20 @@ Optional:
 - `columns_to_include` (List of String) An optional list of columns to include in CDC events. If not provided, all columns will be included. This cannot be used if `columns_to_exclude` is also specified.
 - `is_partitioned` (Boolean) If the source table is partitioned, set this to true and we will ingest data from all of its partitions. You may also need to customize `partition_suffix_regex_pattern` on the source reader.
 - `schema` (String) The name of the schema the table belongs to in the source database. This must be specified if your source database uses schemas (such as PostgreSQL), e.g. `public`.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Import a source reader by using its UUID, which you can find by:
+# 1. Go to the pipeline overview page in the Artie UI
+# 2. Click on the "View UUIDs" button to see all related resource UUIDs
+terraform import artie_source_reader.my_source_reader <source_reader_uuid>
+
+# Then print the state and copy it into your terraform config file
+# (be sure to remove all read-only fields, like `uuid`):
+terraform state show artie_source_reader.my_source_reader
+```

--- a/docs/resources/ssh_tunnel.md
+++ b/docs/resources/ssh_tunnel.md
@@ -35,3 +35,20 @@ resource "artie_ssh_tunnel" "ssh_tunnel" {
 
 - `public_key` (String, Sensitive) When you create an SSH tunnel in Artie, we generate a public/private key pair. Once generated, you'll need to add this public key to `~/.ssh/authorized_keys` on your SSH server.
 - `uuid` (String)
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Import an SSH tunnel by using its UUID, which you can find by:
+# 1. Go to the pipeline overview page in the Artie UI
+# 2. Click on the "View UUIDs" button to see all related resource UUIDs
+terraform import artie_ssh_tunnel.my_ssh_tunnel <ssh_tunnel_uuid>
+
+# Then print the state and copy it into your terraform config file
+# (be sure to remove all read-only fields, like `uuid`):
+terraform state show artie_ssh_tunnel.my_ssh_tunnel
+```

--- a/examples/resources/artie_connector/import.sh
+++ b/examples/resources/artie_connector/import.sh
@@ -1,0 +1,8 @@
+# Import a connector by using its UUID, which you can find by:
+# 1. Go to the pipeline overview page in the Artie UI
+# 2. Click on the "View UUIDs" button to see all related resource UUIDs
+terraform import artie_connector.my_connector <connector_uuid>
+
+# Then print the state and copy it into your terraform config file
+# (be sure to remove all read-only fields, like `uuid`):
+terraform state show artie_connector.my_connector 

--- a/examples/resources/artie_source_reader/import.sh
+++ b/examples/resources/artie_source_reader/import.sh
@@ -1,0 +1,8 @@
+# Import a source reader by using its UUID, which you can find by:
+# 1. Go to the pipeline overview page in the Artie UI
+# 2. Click on the "View UUIDs" button to see all related resource UUIDs
+terraform import artie_source_reader.my_source_reader <source_reader_uuid>
+
+# Then print the state and copy it into your terraform config file
+# (be sure to remove all read-only fields, like `uuid`):
+terraform state show artie_source_reader.my_source_reader 

--- a/examples/resources/artie_ssh_tunnel/import.sh
+++ b/examples/resources/artie_ssh_tunnel/import.sh
@@ -1,0 +1,8 @@
+# Import an SSH tunnel by using its UUID, which you can find by:
+# 1. Go to the pipeline overview page in the Artie UI
+# 2. Click on the "View UUIDs" button to see all related resource UUIDs
+terraform import artie_ssh_tunnel.my_ssh_tunnel <ssh_tunnel_uuid>
+
+# Then print the state and copy it into your terraform config file
+# (be sure to remove all read-only fields, like `uuid`):
+terraform state show artie_ssh_tunnel.my_ssh_tunnel 


### PR DESCRIPTION
Now that we have the "View UUIDs" button, it's easy to see the other related objects to a pipeline.