### PR TITLE
Include advanced settings when validating destination

### DIFF
--- a/internal/artieclient/pipeline.go
+++ b/internal/artieclient/pipeline.go
@@ -122,6 +122,7 @@ func (pc PipelineClient) ValidateDestination(ctx context.Context, pipeline BaseP
 		"sourceReaderUUID": pipeline.SourceReaderUUID,
 		"specificCfg":      pipeline.DestinationConfig,
 		"tables":           pipeline.Tables,
+		"advancedSettings": pipeline.AdvancedSettings,
 	}
 
 	path, err := url.JoinPath(pc.basePath(), "validate-unsaved-destination")


### PR DESCRIPTION
Our endpoint now accepts this and validates it if passed in.