### PR TITLE
Update Artie Client to return body

### DIFF
--- a/internal/artieclient/client.go
+++ b/internal/artieclient/client.go
@@ -86,12 +86,12 @@ func (c Client) makeRequest(ctx context.Context, method string, path string, bod
 		return fmt.Errorf("request failed: %w", err)
 	}
 
+	defer resp.Body.Close()
+
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("artie-client: failed to read response body: %w", err)
 	}
-
-	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
 		return buildError(respBody, resp)

--- a/internal/artieclient/client.go
+++ b/internal/artieclient/client.go
@@ -46,8 +46,7 @@ func buildError(resp *http.Response) error {
 		return fmt.Errorf("artie-client: failed to read response body: %w", err)
 	}
 
-	resp.Body.Close()
-
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("artie-client: not found, request: %q, method: %q, response: %q", resp.Request.URL.String(), resp.Request.Method, string(body))
 	} else if resp.StatusCode >= 400 && resp.StatusCode < 500 { // Client errors


### PR DESCRIPTION
# Changes

This PR logs out the response body if there's an error. When we return a 404 error, sometimes there's additional context such as the connector or specified source reader is not found.

It'd be nice to display that so that our customers can more effectively troubleshoot issues on their own