### PR TITLE
Error instead of warn if a pipeline or shared source reader fails to deploy

### DIFF
--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -309,7 +309,7 @@ func (r *PipelineResource) Create(ctx context.Context, req resource.CreateReques
 	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, createdPipeline)
 
 	if err := r.client.Pipelines().StartPipeline(ctx, createdPipeline.UUID.String()); err != nil {
-		resp.Diagnostics.AddWarning("Unable to start Pipeline", err.Error())
+		resp.Diagnostics.AddError("Unable to start Pipeline", err.Error())
 	}
 }
 
@@ -365,7 +365,7 @@ func (r *PipelineResource) Update(ctx context.Context, req resource.UpdateReques
 	r.SetStateData(ctx, &resp.State, &resp.Diagnostics, updatedPipeline)
 
 	if err := r.client.Pipelines().StartPipeline(ctx, updatedPipeline.UUID.String()); err != nil {
-		resp.Diagnostics.AddWarning("Unable to start Pipeline", err.Error())
+		resp.Diagnostics.AddError("Unable to start Pipeline", err.Error())
 	}
 }
 

--- a/internal/provider/source_reader_resource.go
+++ b/internal/provider/source_reader_resource.go
@@ -228,7 +228,7 @@ func (r *SourceReaderResource) Create(ctx context.Context, req resource.CreateRe
 
 	if sourceReader.IsShared {
 		if err := r.client.SourceReaders().Deploy(ctx, sourceReader.UUID.String()); err != nil {
-			resp.Diagnostics.AddWarning("Unable to deploy Source Reader", err.Error())
+			resp.Diagnostics.AddError("Unable to deploy Source Reader", err.Error())
 		}
 	}
 }
@@ -281,7 +281,7 @@ func (r *SourceReaderResource) Update(ctx context.Context, req resource.UpdateRe
 
 	if updatedSourceReader.IsShared {
 		if err := r.client.SourceReaders().Deploy(ctx, updatedSourceReader.UUID.String()); err != nil {
-			resp.Diagnostics.AddWarning("Unable to deploy Source Reader", err.Error())
+			resp.Diagnostics.AddError("Unable to deploy Source Reader", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
# Changes
- Error instead of warn if a pipeline or shared source reader fails to deploy

# Why Changes are Needed
- Now that we pre-validate before saving a pipeline or source reader, deploying shouldn't fail unless there's an edge case or our api is temporarily unreachable. If this happens, it should be surfaced more clearly so users can retry (or contact us if it's not a transient issue).

# Tests To Pass Before Release

N/A