### PR TITLE
Allow using include & exclude columns in same source reader

### DIFF
--- a/internal/provider/source_reader_resource.go
+++ b/internal/provider/source_reader_resource.go
@@ -153,8 +153,6 @@ func validateSourceReaderConfig(ctx context.Context, configData tfmodels.SourceR
 	if !configData.Tables.IsNull() && !configData.Tables.IsUnknown() {
 		tables := map[string]tfmodels.SourceReaderTable{}
 		diags.Append(configData.Tables.ElementsAs(ctx, &tables, false)...)
-		var usesIncludeColumns bool
-		var usesExcludeColumns bool
 		for tableKey, table := range tables {
 			expectedKey := table.Name.ValueString()
 			if table.Schema.ValueString() != "" {
@@ -162,15 +160,6 @@ func validateSourceReaderConfig(ctx context.Context, configData tfmodels.SourceR
 			}
 			if tableKey != expectedKey {
 				diags.AddError("Table key mismatch", fmt.Sprintf("Table key %q should be %q instead.", tableKey, expectedKey))
-			}
-			if !table.ColumnsToInclude.IsNull() && len(table.ColumnsToInclude.Elements()) > 0 {
-				usesIncludeColumns = true
-			}
-			if !table.ColumnsToExclude.IsNull() && len(table.ColumnsToExclude.Elements()) > 0 {
-				usesExcludeColumns = true
-			}
-			if usesIncludeColumns && usesExcludeColumns {
-				diags.AddError("Invalid table configuration", "You can only use one of `columns_to_include` and `columns_to_exclude` within a source reader.")
 			}
 		}
 	}

--- a/internal/provider/source_reader_resource_test.go
+++ b/internal/provider/source_reader_resource_test.go
@@ -148,8 +148,7 @@ func TestSourceReaderResource_ValidateConfig(t *testing.T) {
 		}
 
 		diags := validateSourceReaderConfig(t.Context(), config)
-		assert.True(t, diags.HasError())
-		assert.Contains(t, diags.Errors()[0].Detail(), "You can only use one of `columns_to_include` and `columns_to_exclude` within a source reader.")
+		assert.False(t, diags.HasError())
 	}
 	{
 		config := tfmodels.SourceReader{


### PR DESCRIPTION
# Changes
No longer need this constraint


# Tests To Pass Before Release

- [ ] `terraform apply` applies your new value (ideally can be seen in dashboard)
- [ ] If your value is not set in terraform state but set in dashboard, when `terraform apply` is run, it does not change the existing value.
- [ ] If your value(s) are changed in dashboard, `terraform plan` should show the diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change confined to config validation and its test; it relaxes a constraint but doesn’t alter API calls or state handling.
> 
> **Overview**
> Removes `validateSourceReaderConfig` enforcement that prevented a source reader from using both `columns_to_include` and `columns_to_exclude` across its `tables` entries.
> 
> Updates the corresponding unit test to expect **no validation error** when a table defines both lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeec43ad5f84d860a331ef2b98d4146afa9458fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->