### PR TITLE
refactor: make IsKnown generic over attr.Value, replace inline null/unknown checks

### DIFF
--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -335,7 +335,7 @@ func (r *PipelineResource) ValidateConfig(ctx context.Context, req resource.Vali
 		)
 	}
 
-	if !configData.Tables.IsNull() && !configData.Tables.IsUnknown() {
+	if tfmodels.IsKnown(configData.Tables) {
 		tables := map[string]tfmodels.Table{}
 		resp.Diagnostics.Append(configData.Tables.ElementsAs(ctx, &tables, false)...)
 
@@ -351,7 +351,7 @@ func (r *PipelineResource) ValidateConfig(ctx context.Context, req resource.Vali
 			if !table.UUID.IsNull() {
 				resp.Diagnostics.AddError("Table.uuid is Read-Only", fmt.Sprintf("%q table should not have `uuid` specified. Please remove this attribute from your config.", tableKey))
 			}
-			if !table.CTIDBackfill.IsNull() && !table.CTIDBackfill.IsUnknown() && table.CTIDBackfill.ValueBool() {
+			if tfmodels.IsKnown(table.CTIDBackfill) && table.CTIDBackfill.ValueBool() {
 				if table.CTIDChunkSize.IsNull() || table.CTIDChunkSize.IsUnknown() {
 					resp.Diagnostics.AddError("CTID chunk size is required", "ctid_chunk_size is required when CTID backfill is enabled.")
 				}
@@ -359,7 +359,7 @@ func (r *PipelineResource) ValidateConfig(ctx context.Context, req resource.Vali
 					resp.Diagnostics.AddError("CTID max parallelism is required", "ctid_max_parallelism is required when CTID backfill is enabled.")
 				}
 			}
-			if !table.ColumnsToEncrypt.IsNull() && !table.ColumnsToEncrypt.IsUnknown() && len(table.ColumnsToEncrypt.Elements()) > 0 {
+			if tfmodels.IsKnown(table.ColumnsToEncrypt) && len(table.ColumnsToEncrypt.Elements()) > 0 {
 				hasColumnsToEncrypt = true
 			}
 			if tfmodels.IsExplicitlyTrue(table.EncryptJSONBColumns) {

--- a/internal/provider/source_reader_resource.go
+++ b/internal/provider/source_reader_resource.go
@@ -160,7 +160,7 @@ func validateSourceReaderConfig(ctx context.Context, configData tfmodels.SourceR
 			diags.AddError("Invalid table configuration", "You must specify at least one table in the `tables` block if `is_shared` is set to true.")
 		}
 	} else {
-		if !configData.Tables.IsNull() && !configData.Tables.IsUnknown() {
+		if tfmodels.IsKnown(configData.Tables) {
 			diags.AddError("Invalid table configuration", "You should not specify a `tables` block if `is_shared` is set to false.")
 		}
 		if configData.StatusOverride.ValueString() != "" {
@@ -168,7 +168,7 @@ func validateSourceReaderConfig(ctx context.Context, configData tfmodels.SourceR
 		}
 	}
 
-	if !configData.Tables.IsNull() && !configData.Tables.IsUnknown() {
+	if tfmodels.IsKnown(configData.Tables) {
 		tables := map[string]tfmodels.SourceReaderTable{}
 		diags.Append(configData.Tables.ElementsAs(ctx, &tables, false)...)
 		for tableKey, table := range tables {

--- a/internal/provider/tfmodels/pipeline_table.go
+++ b/internal/provider/tfmodels/pipeline_table.go
@@ -187,7 +187,7 @@ func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnost
 	diags.Append(softPartitioningDiags...)
 
 	var clientCTIDSettings *artieclient.CTIDSettings
-	if !t.CTIDBackfill.IsNull() && !t.CTIDBackfill.IsUnknown() {
+	if IsKnown(t.CTIDBackfill) {
 		clientCTIDSettings = &artieclient.CTIDSettings{
 			Enabled:        t.CTIDBackfill.ValueBool(),
 			ChunkSize:      uint(t.CTIDChunkSize.ValueInt64()),

--- a/internal/provider/tfmodels/source_reader.go
+++ b/internal/provider/tfmodels/source_reader.go
@@ -139,7 +139,7 @@ func (s SourceReader) toAPISettings(ctx context.Context) (openapi.PayloadsSource
 		settings.MessageCompression = &mc
 	}
 
-	if !s.DatabasesToUnify.IsNull() && !s.DatabasesToUnify.IsUnknown() {
+	if IsKnown(s.DatabasesToUnify) {
 		databasesToUnify, listDiags := parseOptionalList[string](ctx, s.DatabasesToUnify)
 		diags.Append(listDiags...)
 		if diags.HasError() {

--- a/internal/provider/tfmodels/util.go
+++ b/internal/provider/tfmodels/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -100,16 +101,16 @@ func IsKnownAndNonEmpty(value types.String) bool {
 }
 
 // IsKnown returns true if the value is neither null nor unknown.
-func IsKnown(value types.String) bool {
+func IsKnown[T attr.Value](value T) bool {
 	return !value.IsNull() && !value.IsUnknown()
 }
 
 // IsExplicitlyTrue returns true if the value is explicitly set (not null/unknown) and is true.
 func IsExplicitlyTrue(value types.Bool) bool {
-	return !value.IsNull() && !value.IsUnknown() && value.ValueBool()
+	return IsKnown(value) && value.ValueBool()
 }
 
 // IsExplicitlyFalse returns true if the value is explicitly set (not null/unknown) and is false.
 func IsExplicitlyFalse(value types.Bool) bool {
-	return !value.IsNull() && !value.IsUnknown() && !value.ValueBool()
+	return IsKnown(value) && !value.ValueBool()
 }


### PR DESCRIPTION
## Problem

Now that `IsKnown` exists, there were still 6 inline `!IsNull() && !IsUnknown()` guards scattered across the codebase that could use it.

## Fix

Made `IsKnown` generic over `attr.Value` so it works with any Terraform type (`types.String`, `types.Bool`, `types.List`, `types.Map`, etc.), not just `types.String`.

Also cleaned up `IsExplicitlyTrue` / `IsExplicitlyFalse` in `util.go` to use `IsKnown` internally instead of duplicating the null/unknown check.

## Changes

- `tfmodels/util.go` — `IsKnown[T attr.Value]` generic; `IsExplicitlyTrue`/`IsExplicitlyFalse` use it
- `tfmodels/source_reader.go` — `DatabasesToUnify` guard uses `IsKnown`
- `tfmodels/pipeline_table.go` — `CTIDBackfill` guard uses `IsKnown`
- `provider/source_reader_resource.go` — two `Tables` guards use `tfmodels.IsKnown`
- `provider/pipeline_resource.go` — `Tables`, `CTIDBackfill`, `ColumnsToEncrypt` guards use `tfmodels.IsKnown`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent null/unknown semantics; no API or validation rule changes intended.
> 
> **Overview**
> Refactors Terraform attribute “known value” checks by generalizing **`IsKnown`** to any `attr.Value` (maps, lists, bools, strings, etc.) and routing scattered `!IsNull() && !IsUnknown()` guards through it.
> 
> **`IsExplicitlyTrue`** / **`IsExplicitlyFalse`** now delegate to **`IsKnown`** instead of duplicating null/unknown logic. Call sites updated in pipeline and source reader validation, pipeline table CTID mapping, and source reader `databases_to_unify` conversion—behavior should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2fc75edc0c8d4d57337af52dccc6abc8c6e2a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->