### PR TITLE
fix(pipeline): round-trip table-level bool settings set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
 ## 0.1.0 (Unreleased)
 
 FEATURES:
+
+BUG FIXES:
+
+* `artie_pipeline`: Fixed a "provider produced an inconsistent result after apply"
+  error when a table-level boolean setting (e.g. `encrypt_jsonb_columns`) was set
+  explicitly to `false`. The API persists these "absent means off" toggles as null
+  when false, so they now read back as `false` instead of `null`, allowing an
+  explicit `false` to round-trip consistently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
 ## 0.1.0 (Unreleased)
 
 FEATURES:
-
-BUG FIXES:
-
-* `artie_pipeline`: Fixed a "provider produced an inconsistent result after apply"
-  error when a table-level boolean setting (e.g. `encrypt_jsonb_columns`) was set
-  explicitly to `false`. The API persists these "absent means off" toggles as null
-  when false, so they now read back as `false` instead of `null`, allowing an
-  explicit `false` to round-trip consistently.

--- a/internal/provider/tfmodels/pipeline_table.go
+++ b/internal/provider/tfmodels/pipeline_table.go
@@ -279,9 +279,8 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 			ColumnsToHash:      colsToHash,
 			ColumnsToCompress:  colsToCompress,
 			ColumnsToEncrypt:   colsToEncrypt,
-			// These "absent means off" toggles are stored as nil by the API when false. Coalesce
-			// nil to false (instead of null) so an explicit `false` in the config round-trips
-			// consistently and Terraform's post-apply consistency check doesn't error on false -> null.
+			// The API stores these "absent means off" toggles as nil when false; coalesce nil to
+			// false so an explicit `false` round-trips without a post-apply consistency error.
 			EncryptJSONBColumns:  boolPointerValueOrFalse(apiTable.AdvancedSettings.EncryptJSONBColumns),
 			SkipDeletes:          boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipDeletes),
 			UnifyAcrossSchemas:   boolPointerValueOrFalse(apiTable.AdvancedSettings.UnifyAcrossSchemas),

--- a/internal/provider/tfmodels/pipeline_table.go
+++ b/internal/provider/tfmodels/pipeline_table.go
@@ -268,29 +268,32 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 		}
 
 		tables[tableKey] = Table{
-			UUID:                 types.StringValue(apiTable.UUID.String()),
-			Name:                 types.StringValue(apiTable.Name),
-			Schema:               types.StringValue(apiTable.Schema),
-			EnableHistoryMode:    types.BoolValue(apiTable.EnableHistoryMode),
-			DisableReplication:   types.BoolValue(apiTable.DisableReplication),
-			Alias:                types.StringPointerValue(apiTable.AdvancedSettings.Alias),
-			ExcludeColumns:       colsToExclude,
-			IncludeColumns:       colsToInclude,
-			ColumnsToHash:        colsToHash,
-			ColumnsToCompress:    colsToCompress,
-			ColumnsToEncrypt:     colsToEncrypt,
-			EncryptJSONBColumns:  types.BoolPointerValue(apiTable.AdvancedSettings.EncryptJSONBColumns),
-			SkipDeletes:          types.BoolPointerValue(apiTable.AdvancedSettings.SkipDeletes),
-			UnifyAcrossSchemas:   types.BoolPointerValue(apiTable.AdvancedSettings.UnifyAcrossSchemas),
-			UnifyAcrossDatabases: types.BoolPointerValue(apiTable.AdvancedSettings.UnifyAcrossDatabases),
+			UUID:               types.StringValue(apiTable.UUID.String()),
+			Name:               types.StringValue(apiTable.Name),
+			Schema:             types.StringValue(apiTable.Schema),
+			EnableHistoryMode:  types.BoolValue(apiTable.EnableHistoryMode),
+			DisableReplication: types.BoolValue(apiTable.DisableReplication),
+			Alias:              types.StringPointerValue(apiTable.AdvancedSettings.Alias),
+			ExcludeColumns:     colsToExclude,
+			IncludeColumns:     colsToInclude,
+			ColumnsToHash:      colsToHash,
+			ColumnsToCompress:  colsToCompress,
+			ColumnsToEncrypt:   colsToEncrypt,
+			// These "absent means off" toggles are stored as nil by the API when false. Coalesce
+			// nil to false (instead of null) so an explicit `false` in the config round-trips
+			// consistently and Terraform's post-apply consistency check doesn't error on false -> null.
+			EncryptJSONBColumns:  boolPointerValueOrFalse(apiTable.AdvancedSettings.EncryptJSONBColumns),
+			SkipDeletes:          boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipDeletes),
+			UnifyAcrossSchemas:   boolPointerValueOrFalse(apiTable.AdvancedSettings.UnifyAcrossSchemas),
+			UnifyAcrossDatabases: boolPointerValueOrFalse(apiTable.AdvancedSettings.UnifyAcrossDatabases),
 			MergePredicates:      mergePredicates,
 			SoftPartitioning:     softPartitioning,
-			BackfillHistoryTable: types.BoolPointerValue(apiTable.AdvancedSettings.ShouldBackfillHistoryTable),
+			BackfillHistoryTable: boolPointerValueOrFalse(apiTable.AdvancedSettings.ShouldBackfillHistoryTable),
 			CTIDBackfill:         ctidBackfill,
 			CTIDChunkSize:        ctidChunkSize,
 			CTIDMaxParallelism:   ctidMaxParallelism,
-			SkipBackfill:         types.BoolPointerValue(apiTable.AdvancedSettings.SkipBackfill),
-			SkipNoOpUpdates:      types.BoolPointerValue(apiTable.AdvancedSettings.SkipNoOpUpdates),
+			SkipBackfill:         boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipBackfill),
+			SkipNoOpUpdates:      boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipNoOpUpdates),
 		}
 	}
 

--- a/internal/provider/tfmodels/pipeline_table_test.go
+++ b/internal/provider/tfmodels/pipeline_table_test.go
@@ -1,0 +1,95 @@
+package tfmodels
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"terraform-provider-artie/internal/artieclient"
+)
+
+func TestTablesFromAPIModel_NilBoolSettingsReadBackAsFalse(t *testing.T) {
+	// When the API returns nil for "absent means off" toggles (which it does when they are
+	// false), they must read back as an explicit `false`, not null. Otherwise an explicit
+	// `false` in the Terraform config triggers a post-apply consistency error (false -> null).
+	apiTables := []artieclient.Table{
+		{
+			UUID:   uuid.New(),
+			Name:   "billing_counter_event",
+			Schema: "task_mgmt",
+			AdvancedSettings: artieclient.AdvancedTableSettings{
+				EncryptJSONBColumns:        nil,
+				SkipDeletes:                nil,
+				UnifyAcrossSchemas:         nil,
+				UnifyAcrossDatabases:       nil,
+				ShouldBackfillHistoryTable: nil,
+				SkipBackfill:               nil,
+				SkipNoOpUpdates:            nil,
+			},
+		},
+	}
+
+	tables, diags := TablesFromAPIModel(t.Context(), apiTables)
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+
+	table, ok := tables["task_mgmt.billing_counter_event"]
+	assert.True(t, ok, "expected table keyed by schema.name")
+
+	for name, value := range map[string]bool{
+		"encrypt_jsonb_columns":  table.EncryptJSONBColumns.IsNull(),
+		"skip_deletes":           table.SkipDeletes.IsNull(),
+		"unify_across_schemas":   table.UnifyAcrossSchemas.IsNull(),
+		"unify_across_databases": table.UnifyAcrossDatabases.IsNull(),
+		"backfill_history_table": table.BackfillHistoryTable.IsNull(),
+		"skip_backfill":          table.SkipBackfill.IsNull(),
+		"skip_no_op_updates":     table.SkipNoOpUpdates.IsNull(),
+	} {
+		assert.False(t, value, "%s should not read back as null", name)
+	}
+
+	assert.False(t, table.EncryptJSONBColumns.ValueBool())
+	assert.False(t, table.SkipDeletes.ValueBool())
+	assert.False(t, table.UnifyAcrossSchemas.ValueBool())
+	assert.False(t, table.UnifyAcrossDatabases.ValueBool())
+	assert.False(t, table.BackfillHistoryTable.ValueBool())
+	assert.False(t, table.SkipBackfill.ValueBool())
+	assert.False(t, table.SkipNoOpUpdates.ValueBool())
+}
+
+func TestTablesFromAPIModel_BoolSettingsRoundTripExplicitValues(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	apiTables := []artieclient.Table{
+		{
+			UUID: uuid.New(),
+			Name: "orders",
+			AdvancedSettings: artieclient.AdvancedTableSettings{
+				EncryptJSONBColumns: &trueVal,
+				SkipDeletes:         &falseVal,
+			},
+		},
+	}
+
+	tables, diags := TablesFromAPIModel(t.Context(), apiTables)
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+
+	table := tables["orders"]
+	assert.True(t, table.EncryptJSONBColumns.ValueBool(), "explicit true should round-trip as true")
+	assert.False(t, table.SkipDeletes.IsNull(), "explicit false should not read back as null")
+	assert.False(t, table.SkipDeletes.ValueBool(), "explicit false should round-trip as false")
+}
+
+func TestBoolPointerValueOrFalse(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	assert.True(t, boolPointerValueOrFalse(&trueVal).IsNull() == false)
+	assert.True(t, boolPointerValueOrFalse(&trueVal).ValueBool())
+
+	assert.False(t, boolPointerValueOrFalse(&falseVal).IsNull())
+	assert.False(t, boolPointerValueOrFalse(&falseVal).ValueBool())
+
+	assert.False(t, boolPointerValueOrFalse(nil).IsNull(), "nil should coalesce to a known false, not null")
+	assert.False(t, boolPointerValueOrFalse(nil).ValueBool())
+}

--- a/internal/provider/tfmodels/util.go
+++ b/internal/provider/tfmodels/util.go
@@ -90,6 +90,18 @@ func parseOptionalObject[T any](ctx context.Context, value *types.Object) (*T, d
 	return &t, diags
 }
 
+// boolPointerValueOrFalse converts a *bool from the API into a Terraform Bool, treating a nil
+// pointer as false rather than null. The API persists these "absent means off" toggles as nil
+// when they are false, so coalescing nil to false lets an explicit `false` in the config
+// round-trip consistently and avoids Terraform's post-apply "produced an unexpected new value"
+// consistency error (false -> null).
+func boolPointerValueOrFalse(value *bool) types.Bool {
+	if value == nil {
+		return types.BoolValue(false)
+	}
+	return types.BoolValue(*value)
+}
+
 // IsKnownAndEmpty returns true if the value is known (not null/unknown) and is an empty string.
 func IsKnownAndEmpty(value types.String) bool {
 	return !value.IsUnknown() && value.ValueString() == ""

--- a/internal/provider/tfmodels/util.go
+++ b/internal/provider/tfmodels/util.go
@@ -90,11 +90,9 @@ func parseOptionalObject[T any](ctx context.Context, value *types.Object) (*T, d
 	return &t, diags
 }
 
-// boolPointerValueOrFalse converts a *bool from the API into a Terraform Bool, treating a nil
-// pointer as false rather than null. The API persists these "absent means off" toggles as nil
-// when they are false, so coalescing nil to false lets an explicit `false` in the config
-// round-trip consistently and avoids Terraform's post-apply "produced an unexpected new value"
-// consistency error (false -> null).
+// boolPointerValueOrFalse converts a *bool from the API into a Terraform Bool, treating nil
+// as false rather than null. The API stores these "absent means off" toggles as nil when
+// false, so this lets an explicit `false` round-trip without a post-apply consistency error.
 func boolPointerValueOrFalse(value *bool) types.Bool {
 	if value == nil {
 		return types.BoolValue(false)


### PR DESCRIPTION
Fixes the "Provider produced inconsistent result after apply" error when a table-level boolean setting is explicitly set to `false`.

## Problem

```
Error: Provider produced inconsistent result after apply
...
.tables["public.orders"].encrypt_jsonb_columns: was cty.False, but now null.
```

When `encrypt_jsonb_columns = false` (or any sibling table toggle) is passed explicitly, the apply succeeds but the read-back returns `null` instead of `false`. Terraform's post-apply consistency check catches the mismatch and errors out.

## Root cause

The table-level bool settings are `*bool` on the API model and the backend persists them as `null` (nil pointer) when they are `false`. On read-back, `TablesFromAPIModel` used `types.BoolPointerValue(nil)`, which produces a Terraform **null** — but the plan had an explicit **`false`**, so the values diverge.

This was a latent bug shared by every `*bool` table setting read back this way, not just `encrypt_jsonb_columns`: `skip_deletes`, `unify_across_schemas`, `unify_across_databases`, `backfill_history_table`, `skip_backfill`, `skip_no_op_updates`.

## Fix

These are all "absent means off" toggles, so `false` and `null` are semantically equivalent and `false` is the correct stable value. Added a `boolPointerValueOrFalse` helper that coalesces `nil → false`, and applied it to all seven settings so they round-trip `false → false` consistently.

## Tests

- `TestTablesFromAPIModel_NilBoolSettingsReadBackAsFalse` — nil API values read back as known `false`, never null.
- `TestTablesFromAPIModel_BoolSettingsRoundTripExplicitValues` — explicit `true`/`false` round-trip correctly.
- `TestBoolPointerValueOrFalse` — unit coverage for the helper.

`go test ./...` and `golangci-lint run ./...` both pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path mapping change in the Terraform provider only; no API or write-path behavior changes, with regression tests added.
> 
> **Overview**
> Fixes **post-apply inconsistent result** errors when pipeline table toggles are set to `false` in Terraform. The API returns `nil` for those “off” settings; read-back used to map that to Terraform **null**, which disagreed with an explicit **`false`** after apply.
> 
> Adds **`boolPointerValueOrFalse`** and uses it in **`TablesFromAPIModel`** for seven advanced table booleans (`encrypt_jsonb_columns`, `skip_deletes`, unify flags, `backfill_history_table`, `skip_backfill`, `skip_no_op_updates`) so **`nil` → known `false`**. New tests cover nil read-back, explicit true/false round-trip, and the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb97e78232975e39ace267893e110cee1141273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of unspecified boolean settings in advanced table configurations to consistently default to "false," preventing post-apply plan inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->