### PR TITLE
fix(pipeline): round-trip disable_alerts set to false

### DIFF
--- a/internal/provider/tfmodels/pipeline.go
+++ b/internal/provider/tfmodels/pipeline.go
@@ -378,9 +378,7 @@ func PipelineFromAPIModel(ctx context.Context, apiModel artieclient.Pipeline) (P
 		if apiModel.AdvancedSettings.WriteRawBinaryValues != nil {
 			writeRawBinaryValues = types.BoolValue(*apiModel.AdvancedSettings.WriteRawBinaryValues)
 		}
-		if apiModel.AdvancedSettings.DisableAlerts != nil {
-			disableAlerts = types.BoolValue(*apiModel.AdvancedSettings.DisableAlerts)
-		}
+		disableAlerts = boolPointerValueOrFalse(apiModel.AdvancedSettings.DisableAlerts)
 		flushConfigMap := map[string]attr.Value{}
 		if apiModel.AdvancedSettings.FlushIntervalSeconds != nil {
 			flushConfigMap["flush_interval_seconds"] = types.Int64Value(*apiModel.AdvancedSettings.FlushIntervalSeconds)

--- a/internal/provider/tfmodels/pipeline.go
+++ b/internal/provider/tfmodels/pipeline.go
@@ -322,10 +322,10 @@ func PipelineFromAPIModel(ctx context.Context, apiModel artieclient.Pipeline) (P
 	var stagingSchema types.String
 	var forceUTCTimezone types.Bool
 	var writeRawBinaryValues types.Bool
-	var disableAlerts types.Bool
 
-	// This should default to false even if it's omitted from the API response.
+	// These should default to false even if they're omitted from the API response.
 	autoReplicateNewTables := types.BoolValue(false)
+	disableAlerts := types.BoolValue(false)
 	staticColumns, staticColumnsDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: StaticColumnAttrTypes}, []StaticColumn{})
 	diags.Append(staticColumnsDiags...)
 	if diags.HasError() {

--- a/internal/provider/tfmodels/pipeline_test.go
+++ b/internal/provider/tfmodels/pipeline_test.go
@@ -3,10 +3,53 @@ package tfmodels
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+
+	"terraform-provider-artie/internal/artieclient"
 )
+
+func ptr[T any](v T) *T { return &v }
+
+func TestPipelineFromAPIModel_DisableAlertsReadsBackAsFalse(t *testing.T) {
+	// disable_alerts is an "absent means off" toggle. The backend persists false as
+	// nil, so both an omitted value and an explicit false must read back as a stable
+	// false (never null), otherwise Terraform's post-apply consistency check errors:
+	// ".disable_alerts: was cty.False, but now null".
+	base := artieclient.Pipeline{
+		UUID: uuid.New(),
+		BasePipeline: artieclient.BasePipeline{
+			Name:             "test",
+			Tables:           []artieclient.Table{},
+			AdvancedSettings: &artieclient.AdvancedSettings{},
+		},
+	}
+
+	{
+		// DisableAlerts omitted (nil) -> false
+		pipeline, diags := PipelineFromAPIModel(t.Context(), base)
+		assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
+		assert.False(t, pipeline.DisableAlerts.IsNull(), "disable_alerts should not be null when omitted")
+		assert.False(t, pipeline.DisableAlerts.ValueBool())
+	}
+	{
+		// DisableAlerts explicitly false -> false
+		base.AdvancedSettings.DisableAlerts = ptr(false)
+		pipeline, diags := PipelineFromAPIModel(t.Context(), base)
+		assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
+		assert.False(t, pipeline.DisableAlerts.IsNull(), "disable_alerts should not be null when false")
+		assert.False(t, pipeline.DisableAlerts.ValueBool())
+	}
+	{
+		// DisableAlerts explicitly true -> true
+		base.AdvancedSettings.DisableAlerts = ptr(true)
+		pipeline, diags := PipelineFromAPIModel(t.Context(), base)
+		assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
+		assert.True(t, pipeline.DisableAlerts.ValueBool())
+	}
+}
 
 func TestFlushConfigFromAPIModel(t *testing.T) {
 	{


### PR DESCRIPTION
Fixes the "Provider produced inconsistent result after apply" error when `disable_alerts` is explicitly set to `false`.

## Problem

```
Error: Provider produced inconsistent result after apply
When applying changes to artie_pipeline.dynamodb_activity_items, provider produced an unexpected new value: .disable_alerts: was cty.False, but now null.
```

`disable_alerts` (added in #397) hit the same bug class #396 fixed for table-level toggles, just one layer up at pipeline advanced settings.

## Root cause

`PipelineFromAPIModel` declared `disableAlerts` as a zero-value `types.Bool` (Terraform null) and only assigned it when the API returned a non-nil pointer. The backend persists `false` as nil, so an explicit `disable_alerts = false` read back as **null** while the plan had explicit **false** — Terraform's post-apply consistency check catches the divergence and errors.

`auto_replicate_new_tables` has the identical schema but is unaffected because it already defaults to `types.BoolValue(false)`.

## Fix

Default `disableAlerts` to `types.BoolValue(false)` so `false → false` round-trips consistently, matching `auto_replicate_new_tables`.

## Tests

- `TestPipelineFromAPIModel_DisableAlertsReadsBackAsFalse` — verifies nil/false read back as a stable `false` (not null) and true stays true. Confirmed RED without the fix, GREEN with it.
- `go test ./...` clean, `golangci-lint` 0 issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized read-path mapping for one advanced-setting bool; aligns with existing boolPointerValueOrFalse pattern and adds regression tests only.
> 
> **Overview**
> Fixes Terraform **post-apply inconsistency** when `disable_alerts = false` on pipeline advanced settings: the API omits or nils `false`, but the provider used to map that to **null** instead of **false**.
> 
> **`PipelineFromAPIModel`** now initializes `disable_alerts` to `types.BoolValue(false)` (same pattern as `auto_replicate_new_tables`) and sets it via **`boolPointerValueOrFalse`**, matching the table-level toggle fix elsewhere in tfmodels.
> 
> Adds **`TestPipelineFromAPIModel_DisableAlertsReadsBackAsFalse`** for omitted nil, explicit false, and explicit true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b9fea71aa9d4b3c6dbe34bf7d8886c6733cc75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->