### PR TITLE
Add table range settings support

### DIFF
--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -117,6 +117,7 @@ Optional:
 - `enable_history_mode` (Boolean) If set to true, we will create an additional table in the destination (suffixed with `__history`) to store all changes to the source table over time.
 - `encrypt_jsonb_columns` (Boolean) If set to true, all JSONB (struct) columns will be automatically encrypted before writing to the destination. Requires `encryption_key_uuid` to be set on the pipeline.
 - `merge_predicates` (Attributes List) Optional: if the destination table is partitioned, specify the partition column(s) and type. This helps merge performance and currently only applies to Snowflake and BigQuery. For BigQuery, only one column can be specified and it may be either a time-partitioned or an integer range-partitioned column; set `partition_type` to 'time' or 'integer' accordingly. (see [below for nested schema](#nestedatt--tables--merge_predicates))
+- `range_settings` (Attributes) Optional: configuration for range-based parallel backfill. This is typically used for large tables with an integer primary key or another suitable monotonic range column. (see [below for nested schema](#nestedatt--tables--range_settings))
 - `schema` (String) The name of the schema the table belongs to in the source database. This must be specified if your source database uses schemas (such as PostgreSQL), e.g. `public`.
 - `skip_backfill` (Boolean) If set to true, Artie will skip backfilling this table and only process new changes going forward.
 - `skip_deletes` (Boolean) If set to true, we will skip delete events for this table and only process insert and update events.
@@ -139,6 +140,17 @@ Required:
 Optional:
 
 - `partition_type` (String) The type of partition to use. One of 'time' or 'integer'. Required for BigQuery.
+
+
+<a id="nestedatt--tables--range_settings"></a>
+### Nested Schema for `tables.range_settings`
+
+Required:
+
+- `batch_size` (Number) The batch size Artie should use while processing each range backfill chunk. Set to 0 to use Artie's default.
+- `chunk_size` (Number) The number of source rows or range units Artie should target per range backfill chunk.
+- `enabled` (Boolean) Whether range-based parallel backfill is enabled for this table.
+- `max_parallelism` (Number) The maximum number of range backfill chunks Artie should process in parallel for this table.
 
 
 <a id="nestedatt--tables--soft_partitioning"></a>

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -117,7 +117,10 @@ Optional:
 - `enable_history_mode` (Boolean) If set to true, we will create an additional table in the destination (suffixed with `__history`) to store all changes to the source table over time.
 - `encrypt_jsonb_columns` (Boolean) If set to true, all JSONB (struct) columns will be automatically encrypted before writing to the destination. Requires `encryption_key_uuid` to be set on the pipeline.
 - `merge_predicates` (Attributes List) Optional: if the destination table is partitioned, specify the partition column(s) and type. This helps merge performance and currently only applies to Snowflake and BigQuery. For BigQuery, only one column can be specified and it may be either a time-partitioned or an integer range-partitioned column; set `partition_type` to 'time' or 'integer' accordingly. (see [below for nested schema](#nestedatt--tables--merge_predicates))
-- `range_settings` (Attributes) Optional: configuration for range-based parallel backfill. This is typically used for large tables with an integer primary key or another suitable monotonic range column. (see [below for nested schema](#nestedatt--tables--range_settings))
+- `range_backfill` (Boolean) If set to true, enables range-based parallel backfill for this table.
+- `range_batch_size` (Number) The batch size Artie should use while processing each range backfill chunk. Set to 0 to use Artie's default. This is only applicable if `range_backfill` is set to true.
+- `range_chunk_size` (Number) The number of source rows or range units Artie should target per range backfill chunk. This is only applicable if `range_backfill` is set to true.
+- `range_max_parallelism` (Number) The maximum number of range backfill chunks Artie should process in parallel for this table. This is only applicable if `range_backfill` is set to true.
 - `schema` (String) The name of the schema the table belongs to in the source database. This must be specified if your source database uses schemas (such as PostgreSQL), e.g. `public`.
 - `skip_backfill` (Boolean) If set to true, Artie will skip backfilling this table and only process new changes going forward.
 - `skip_deletes` (Boolean) If set to true, we will skip delete events for this table and only process insert and update events.
@@ -140,17 +143,6 @@ Required:
 Optional:
 
 - `partition_type` (String) The type of partition to use. One of 'time' or 'integer'. Required for BigQuery.
-
-
-<a id="nestedatt--tables--range_settings"></a>
-### Nested Schema for `tables.range_settings`
-
-Required:
-
-- `batch_size` (Number) The batch size Artie should use while processing each range backfill chunk. Set to 0 to use Artie's default.
-- `chunk_size` (Number) The number of source rows or range units Artie should target per range backfill chunk.
-- `enabled` (Boolean) Whether range-based parallel backfill is enabled for this table.
-- `max_parallelism` (Number) The maximum number of range backfill chunks Artie should process in parallel for this table.
 
 
 <a id="nestedatt--tables--soft_partitioning"></a>

--- a/internal/artieclient/pipeline.go
+++ b/internal/artieclient/pipeline.go
@@ -84,6 +84,13 @@ type CTIDSettings struct {
 	MaxParallelism uint `json:"maxParallelism"`
 }
 
+type RangeSettings struct {
+	Enabled        bool `json:"enabled"`
+	ChunkSize      int  `json:"chunksSize"`
+	MaxParallelism int  `json:"maxParallelism"`
+	BatchSize      int  `json:"batchSize"`
+}
+
 type AdvancedTableSettings struct {
 	Alias                      *string           `json:"alias"`
 	ExcludeColumns             *[]string         `json:"excludeColumns"`
@@ -99,6 +106,7 @@ type AdvancedTableSettings struct {
 	SoftPartitioning           *SoftPartitioning `json:"softPartitioning,omitempty"`
 	ShouldBackfillHistoryTable *bool             `json:"shouldBackfillHistoryTable"`
 	CTIDSettings               *CTIDSettings     `json:"ctidSettings,omitempty"`
+	RangeSettings              *RangeSettings    `json:"rangeSettings,omitempty"`
 	SkipBackfill               *bool             `json:"skipBackfill"`
 	SkipNoOpUpdates            *bool             `json:"skipNoOpUpdates"`
 }

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -82,40 +82,12 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 						"ctid_backfill":          schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, enables CTID backfill for this table. This is only applicable if the source type is `postgres`."},
 						"ctid_chunk_size":        schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.Between(100000, 1000000)}, MarkdownDescription: "The chunk size to use for CTID backfill. This should be between 100,000 and 1,000,000. This is only applicable if the source type is `postgres` and `ctid_backfill` is set to true."},
 						"ctid_max_parallelism":   schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.Between(5, 20)}, MarkdownDescription: "The maximum parallelism for CTID backfill. This should be between 5 and 20. This is only applicable if the source type is `postgres` and `ctid_backfill` is set to true."},
-						"range_settings": schema.SingleNestedAttribute{
-							Optional:            true,
-							PlanModifiers:       []planmodifier.Object{objectplanmodifier.UseNonNullStateForUnknown()},
-							MarkdownDescription: "Optional: configuration for range-based parallel backfill. This is typically used for large tables with an integer primary key or another suitable monotonic range column.",
-							Attributes: map[string]schema.Attribute{
-								"enabled": schema.BoolAttribute{
-									Required:            true,
-									MarkdownDescription: "Whether range-based parallel backfill is enabled for this table.",
-								},
-								"chunk_size": schema.Int64Attribute{
-									Required:            true,
-									MarkdownDescription: "The number of source rows or range units Artie should target per range backfill chunk.",
-									Validators: []validator.Int64{
-										int64validator.AtLeast(0),
-									},
-								},
-								"max_parallelism": schema.Int64Attribute{
-									Required:            true,
-									MarkdownDescription: "The maximum number of range backfill chunks Artie should process in parallel for this table.",
-									Validators: []validator.Int64{
-										int64validator.AtLeast(0),
-									},
-								},
-								"batch_size": schema.Int64Attribute{
-									Required:            true,
-									MarkdownDescription: "The batch size Artie should use while processing each range backfill chunk. Set to 0 to use Artie's default.",
-									Validators: []validator.Int64{
-										int64validator.AtLeast(0),
-									},
-								},
-							},
-						},
-						"skip_backfill":      schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, Artie will skip backfilling this table and only process new changes going forward."},
-						"skip_no_op_updates": schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, update events where the before and after rows are identical (after applying column inclusion/exclusion) will be skipped. Only supported for Postgres and requires REPLICA IDENTITY FULL."},
+						"range_backfill":         schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, enables range-based parallel backfill for this table."},
+						"range_chunk_size":       schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(0)}, MarkdownDescription: "The number of source rows or range units Artie should target per range backfill chunk. This is only applicable if `range_backfill` is set to true."},
+						"range_max_parallelism":  schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(0)}, MarkdownDescription: "The maximum number of range backfill chunks Artie should process in parallel for this table. This is only applicable if `range_backfill` is set to true."},
+						"range_batch_size":       schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.AtLeast(0)}, MarkdownDescription: "The batch size Artie should use while processing each range backfill chunk. Set to 0 to use Artie's default. This is only applicable if `range_backfill` is set to true."},
+						"skip_backfill":          schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, Artie will skip backfilling this table and only process new changes going forward."},
+						"skip_no_op_updates":     schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, update events where the before and after rows are identical (after applying column inclusion/exclusion) will be skipped. Only supported for Postgres and requires REPLICA IDENTITY FULL."},
 						"merge_predicates": schema.ListNestedAttribute{
 							Optional:            true,
 							Computed:            true,
@@ -390,6 +362,17 @@ func (r *PipelineResource) ValidateConfig(ctx context.Context, req resource.Vali
 				}
 				if table.CTIDMaxParallelism.IsNull() || table.CTIDMaxParallelism.IsUnknown() {
 					resp.Diagnostics.AddError("CTID max parallelism is required", "ctid_max_parallelism is required when CTID backfill is enabled.")
+				}
+			}
+			if tfmodels.IsKnown(table.RangeBackfill) && table.RangeBackfill.ValueBool() {
+				if table.RangeChunkSize.IsNull() || table.RangeChunkSize.IsUnknown() {
+					resp.Diagnostics.AddError("Range chunk size is required", "range_chunk_size is required when range_backfill is enabled.")
+				}
+				if table.RangeMaxParallelism.IsNull() || table.RangeMaxParallelism.IsUnknown() {
+					resp.Diagnostics.AddError("Range max parallelism is required", "range_max_parallelism is required when range_backfill is enabled.")
+				}
+				if table.RangeBatchSize.IsNull() || table.RangeBatchSize.IsUnknown() {
+					resp.Diagnostics.AddError("Range batch size is required", "range_batch_size is required when range_backfill is enabled.")
 				}
 			}
 			if tfmodels.IsKnown(table.ColumnsToEncrypt) && len(table.ColumnsToEncrypt.Elements()) > 0 {

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -82,8 +82,41 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 						"ctid_backfill":          schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, enables CTID backfill for this table. This is only applicable if the source type is `postgres`."},
 						"ctid_chunk_size":        schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.Between(100000, 1000000)}, MarkdownDescription: "The chunk size to use for CTID backfill. This should be between 100,000 and 1,000,000. This is only applicable if the source type is `postgres` and `ctid_backfill` is set to true."},
 						"ctid_max_parallelism":   schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.Between(5, 20)}, MarkdownDescription: "The maximum parallelism for CTID backfill. This should be between 5 and 20. This is only applicable if the source type is `postgres` and `ctid_backfill` is set to true."},
-						"skip_backfill":          schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, Artie will skip backfilling this table and only process new changes going forward."},
-						"skip_no_op_updates":     schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, update events where the before and after rows are identical (after applying column inclusion/exclusion) will be skipped. Only supported for Postgres and requires REPLICA IDENTITY FULL."},
+						"range_settings": schema.SingleNestedAttribute{
+							Optional:            true,
+							Computed:            true,
+							PlanModifiers:       []planmodifier.Object{objectplanmodifier.UseNonNullStateForUnknown()},
+							MarkdownDescription: "Optional: configuration for range-based parallel backfill. This is typically used for large tables with an integer primary key or another suitable monotonic range column.",
+							Attributes: map[string]schema.Attribute{
+								"enabled": schema.BoolAttribute{
+									Required:            true,
+									MarkdownDescription: "Whether range-based parallel backfill is enabled for this table.",
+								},
+								"chunk_size": schema.Int64Attribute{
+									Required:            true,
+									MarkdownDescription: "The number of source rows or range units Artie should target per range backfill chunk.",
+									Validators: []validator.Int64{
+										int64validator.AtLeast(0),
+									},
+								},
+								"max_parallelism": schema.Int64Attribute{
+									Required:            true,
+									MarkdownDescription: "The maximum number of range backfill chunks Artie should process in parallel for this table.",
+									Validators: []validator.Int64{
+										int64validator.AtLeast(0),
+									},
+								},
+								"batch_size": schema.Int64Attribute{
+									Required:            true,
+									MarkdownDescription: "The batch size Artie should use while processing each range backfill chunk. Set to 0 to use Artie's default.",
+									Validators: []validator.Int64{
+										int64validator.AtLeast(0),
+									},
+								},
+							},
+						},
+						"skip_backfill":      schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, Artie will skip backfilling this table and only process new changes going forward."},
+						"skip_no_op_updates": schema.BoolAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()}, MarkdownDescription: "If set to true, update events where the before and after rows are identical (after applying column inclusion/exclusion) will be skipped. Only supported for Postgres and requires REPLICA IDENTITY FULL."},
 						"merge_predicates": schema.ListNestedAttribute{
 							Optional:            true,
 							Computed:            true,

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -84,7 +84,6 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 						"ctid_max_parallelism":   schema.Int64Attribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseNonNullStateForUnknown()}, Validators: []validator.Int64{int64validator.Between(5, 20)}, MarkdownDescription: "The maximum parallelism for CTID backfill. This should be between 5 and 20. This is only applicable if the source type is `postgres` and `ctid_backfill` is set to true."},
 						"range_settings": schema.SingleNestedAttribute{
 							Optional:            true,
-							Computed:            true,
 							PlanModifiers:       []planmodifier.Object{objectplanmodifier.UseNonNullStateForUnknown()},
 							MarkdownDescription: "Optional: configuration for range-based parallel backfill. This is typically used for large tables with an integer primary key or another suitable monotonic range column.",
 							Attributes: map[string]schema.Attribute{

--- a/internal/provider/tfmodels/pipeline_table.go
+++ b/internal/provider/tfmodels/pipeline_table.go
@@ -91,43 +91,6 @@ func SoftPartitioningFromAPIModel(ctx context.Context, apiSoftPartitioning *arti
 	})
 }
 
-type RangeSettings struct {
-	Enabled        types.Bool  `tfsdk:"enabled"`
-	ChunkSize      types.Int64 `tfsdk:"chunk_size"`
-	MaxParallelism types.Int64 `tfsdk:"max_parallelism"`
-	BatchSize      types.Int64 `tfsdk:"batch_size"`
-}
-
-func (r RangeSettings) ToAPIModel() *artieclient.RangeSettings {
-	return &artieclient.RangeSettings{
-		Enabled:        r.Enabled.ValueBool(),
-		ChunkSize:      int(r.ChunkSize.ValueInt64()),
-		MaxParallelism: int(r.MaxParallelism.ValueInt64()),
-		BatchSize:      int(r.BatchSize.ValueInt64()),
-	}
-}
-
-var RangeSettingsAttrTypes = map[string]attr.Type{
-	"enabled":         types.BoolType,
-	"chunk_size":      types.Int64Type,
-	"max_parallelism": types.Int64Type,
-	"batch_size":      types.Int64Type,
-}
-
-func RangeSettingsFromAPIModel(apiRangeSettings *artieclient.RangeSettings) (types.Object, diag.Diagnostics) {
-	attrTypes := RangeSettingsAttrTypes
-	if apiRangeSettings == nil {
-		return types.ObjectNull(attrTypes), nil
-	}
-
-	return types.ObjectValue(attrTypes, map[string]attr.Value{
-		"enabled":         types.BoolValue(apiRangeSettings.Enabled),
-		"chunk_size":      types.Int64Value(int64(apiRangeSettings.ChunkSize)),
-		"max_parallelism": types.Int64Value(int64(apiRangeSettings.MaxParallelism)),
-		"batch_size":      types.Int64Value(int64(apiRangeSettings.BatchSize)),
-	})
-}
-
 type Table struct {
 	UUID               types.String `tfsdk:"uuid"`
 	Name               types.String `tfsdk:"name"`
@@ -152,7 +115,10 @@ type Table struct {
 	CTIDBackfill         types.Bool   `tfsdk:"ctid_backfill"`
 	CTIDChunkSize        types.Int64  `tfsdk:"ctid_chunk_size"`
 	CTIDMaxParallelism   types.Int64  `tfsdk:"ctid_max_parallelism"`
-	RangeSettings        types.Object `tfsdk:"range_settings"`
+	RangeBackfill        types.Bool   `tfsdk:"range_backfill"`
+	RangeChunkSize       types.Int64  `tfsdk:"range_chunk_size"`
+	RangeMaxParallelism  types.Int64  `tfsdk:"range_max_parallelism"`
+	RangeBatchSize       types.Int64  `tfsdk:"range_batch_size"`
 	SkipBackfill         types.Bool   `tfsdk:"skip_backfill"`
 	SkipNoOpUpdates      types.Bool   `tfsdk:"skip_no_op_updates"`
 }
@@ -179,7 +145,10 @@ var TableAttrTypes = map[string]attr.Type{
 	"ctid_backfill":          types.BoolType,
 	"ctid_chunk_size":        types.Int64Type,
 	"ctid_max_parallelism":   types.Int64Type,
-	"range_settings":         types.ObjectType{AttrTypes: RangeSettingsAttrTypes},
+	"range_backfill":         types.BoolType,
+	"range_chunk_size":       types.Int64Type,
+	"range_max_parallelism":  types.Int64Type,
+	"range_batch_size":       types.Int64Type,
 	"skip_backfill":          types.BoolType,
 	"skip_no_op_updates":     types.BoolType,
 }
@@ -234,12 +203,15 @@ func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnost
 		}
 	}
 
-	rangeSettings, rangeSettingsDiags := parseOptionalObject[RangeSettings](ctx, &t.RangeSettings)
 	var clientRangeSettings *artieclient.RangeSettings
-	if rangeSettings != nil {
-		clientRangeSettings = rangeSettings.ToAPIModel()
+	if IsKnown(t.RangeBackfill) {
+		clientRangeSettings = &artieclient.RangeSettings{
+			Enabled:        t.RangeBackfill.ValueBool(),
+			ChunkSize:      int(t.RangeChunkSize.ValueInt64()),
+			MaxParallelism: int(t.RangeMaxParallelism.ValueInt64()),
+			BatchSize:      int(t.RangeBatchSize.ValueInt64()),
+		}
 	}
-	diags.Append(rangeSettingsDiags...)
 
 	if diags.HasError() {
 		return artieclient.Table{}, diags
@@ -303,9 +275,6 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 		softPartitioning, softPartitioningDiags := SoftPartitioningFromAPIModel(ctx, apiTable.AdvancedSettings.SoftPartitioning)
 		diags.Append(softPartitioningDiags...)
 
-		rangeSettings, rangeSettingsDiags := RangeSettingsFromAPIModel(apiTable.AdvancedSettings.RangeSettings)
-		diags.Append(rangeSettingsDiags...)
-
 		// Extract CTID settings - initialize them to the zero-values (instead of null/unknown) because if
 		// they're not in the api response, that means they're zero. This avoids extra noise in the plan output.
 		ctidBackfill := types.BoolValue(false)
@@ -315,6 +284,17 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 			ctidBackfill = types.BoolValue(apiTable.AdvancedSettings.CTIDSettings.Enabled)
 			ctidChunkSize = types.Int64Value(int64(apiTable.AdvancedSettings.CTIDSettings.ChunkSize))
 			ctidMaxParallelism = types.Int64Value(int64(apiTable.AdvancedSettings.CTIDSettings.MaxParallelism))
+		}
+
+		rangeBackfill := types.BoolValue(false)
+		rangeChunkSize := types.Int64Value(0)
+		rangeMaxParallelism := types.Int64Value(0)
+		rangeBatchSize := types.Int64Value(0)
+		if apiTable.AdvancedSettings.RangeSettings != nil {
+			rangeBackfill = types.BoolValue(apiTable.AdvancedSettings.RangeSettings.Enabled)
+			rangeChunkSize = types.Int64Value(int64(apiTable.AdvancedSettings.RangeSettings.ChunkSize))
+			rangeMaxParallelism = types.Int64Value(int64(apiTable.AdvancedSettings.RangeSettings.MaxParallelism))
+			rangeBatchSize = types.Int64Value(int64(apiTable.AdvancedSettings.RangeSettings.BatchSize))
 		}
 
 		tables[tableKey] = Table{
@@ -341,7 +321,10 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 			CTIDBackfill:         ctidBackfill,
 			CTIDChunkSize:        ctidChunkSize,
 			CTIDMaxParallelism:   ctidMaxParallelism,
-			RangeSettings:        rangeSettings,
+			RangeBackfill:        rangeBackfill,
+			RangeChunkSize:       rangeChunkSize,
+			RangeMaxParallelism:  rangeMaxParallelism,
+			RangeBatchSize:       rangeBatchSize,
 			SkipBackfill:         boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipBackfill),
 			SkipNoOpUpdates:      boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipNoOpUpdates),
 		}

--- a/internal/provider/tfmodels/pipeline_table.go
+++ b/internal/provider/tfmodels/pipeline_table.go
@@ -91,6 +91,43 @@ func SoftPartitioningFromAPIModel(ctx context.Context, apiSoftPartitioning *arti
 	})
 }
 
+type RangeSettings struct {
+	Enabled        types.Bool  `tfsdk:"enabled"`
+	ChunkSize      types.Int64 `tfsdk:"chunk_size"`
+	MaxParallelism types.Int64 `tfsdk:"max_parallelism"`
+	BatchSize      types.Int64 `tfsdk:"batch_size"`
+}
+
+func (r RangeSettings) ToAPIModel() *artieclient.RangeSettings {
+	return &artieclient.RangeSettings{
+		Enabled:        r.Enabled.ValueBool(),
+		ChunkSize:      int(r.ChunkSize.ValueInt64()),
+		MaxParallelism: int(r.MaxParallelism.ValueInt64()),
+		BatchSize:      int(r.BatchSize.ValueInt64()),
+	}
+}
+
+var RangeSettingsAttrTypes = map[string]attr.Type{
+	"enabled":         types.BoolType,
+	"chunk_size":      types.Int64Type,
+	"max_parallelism": types.Int64Type,
+	"batch_size":      types.Int64Type,
+}
+
+func RangeSettingsFromAPIModel(apiRangeSettings *artieclient.RangeSettings) (types.Object, diag.Diagnostics) {
+	attrTypes := RangeSettingsAttrTypes
+	if apiRangeSettings == nil {
+		return types.ObjectNull(attrTypes), nil
+	}
+
+	return types.ObjectValue(attrTypes, map[string]attr.Value{
+		"enabled":         types.BoolValue(apiRangeSettings.Enabled),
+		"chunk_size":      types.Int64Value(int64(apiRangeSettings.ChunkSize)),
+		"max_parallelism": types.Int64Value(int64(apiRangeSettings.MaxParallelism)),
+		"batch_size":      types.Int64Value(int64(apiRangeSettings.BatchSize)),
+	})
+}
+
 type Table struct {
 	UUID               types.String `tfsdk:"uuid"`
 	Name               types.String `tfsdk:"name"`
@@ -115,6 +152,7 @@ type Table struct {
 	CTIDBackfill         types.Bool   `tfsdk:"ctid_backfill"`
 	CTIDChunkSize        types.Int64  `tfsdk:"ctid_chunk_size"`
 	CTIDMaxParallelism   types.Int64  `tfsdk:"ctid_max_parallelism"`
+	RangeSettings        types.Object `tfsdk:"range_settings"`
 	SkipBackfill         types.Bool   `tfsdk:"skip_backfill"`
 	SkipNoOpUpdates      types.Bool   `tfsdk:"skip_no_op_updates"`
 }
@@ -141,6 +179,7 @@ var TableAttrTypes = map[string]attr.Type{
 	"ctid_backfill":          types.BoolType,
 	"ctid_chunk_size":        types.Int64Type,
 	"ctid_max_parallelism":   types.Int64Type,
+	"range_settings":         types.ObjectType{AttrTypes: RangeSettingsAttrTypes},
 	"skip_backfill":          types.BoolType,
 	"skip_no_op_updates":     types.BoolType,
 }
@@ -195,6 +234,13 @@ func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnost
 		}
 	}
 
+	rangeSettings, rangeSettingsDiags := parseOptionalObject[RangeSettings](ctx, &t.RangeSettings)
+	var clientRangeSettings *artieclient.RangeSettings
+	if rangeSettings != nil {
+		clientRangeSettings = rangeSettings.ToAPIModel()
+	}
+	diags.Append(rangeSettingsDiags...)
+
 	if diags.HasError() {
 		return artieclient.Table{}, diags
 	}
@@ -220,6 +266,7 @@ func (t Table) ToAPIModel(ctx context.Context) (artieclient.Table, diag.Diagnost
 			SoftPartitioning:           clientSoftPartitioning,
 			ShouldBackfillHistoryTable: t.BackfillHistoryTable.ValueBoolPointer(),
 			CTIDSettings:               clientCTIDSettings,
+			RangeSettings:              clientRangeSettings,
 			SkipBackfill:               t.SkipBackfill.ValueBoolPointer(),
 			SkipNoOpUpdates:            t.SkipNoOpUpdates.ValueBoolPointer(),
 		},
@@ -256,6 +303,9 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 		softPartitioning, softPartitioningDiags := SoftPartitioningFromAPIModel(ctx, apiTable.AdvancedSettings.SoftPartitioning)
 		diags.Append(softPartitioningDiags...)
 
+		rangeSettings, rangeSettingsDiags := RangeSettingsFromAPIModel(apiTable.AdvancedSettings.RangeSettings)
+		diags.Append(rangeSettingsDiags...)
+
 		// Extract CTID settings - initialize them to the zero-values (instead of null/unknown) because if
 		// they're not in the api response, that means they're zero. This avoids extra noise in the plan output.
 		ctidBackfill := types.BoolValue(false)
@@ -291,6 +341,7 @@ func TablesFromAPIModel(ctx context.Context, apiModelTables []artieclient.Table)
 			CTIDBackfill:         ctidBackfill,
 			CTIDChunkSize:        ctidChunkSize,
 			CTIDMaxParallelism:   ctidMaxParallelism,
+			RangeSettings:        rangeSettings,
 			SkipBackfill:         boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipBackfill),
 			SkipNoOpUpdates:      boolPointerValueOrFalse(apiTable.AdvancedSettings.SkipNoOpUpdates),
 		}

--- a/internal/provider/tfmodels/pipeline_table_test.go
+++ b/internal/provider/tfmodels/pipeline_table_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
 
 	"terraform-provider-artie/internal/artieclient"
@@ -78,6 +80,62 @@ func TestTablesFromAPIModel_BoolSettingsRoundTripExplicitValues(t *testing.T) {
 	assert.True(t, table.EncryptJSONBColumns.ValueBool(), "explicit true should round-trip as true")
 	assert.False(t, table.SkipDeletes.IsNull(), "explicit false should not read back as null")
 	assert.False(t, table.SkipDeletes.ValueBool(), "explicit false should round-trip as false")
+}
+
+func TestTableToAPIModel_RangeSettings(t *testing.T) {
+	rangeSettings, rangeDiags := types.ObjectValueFrom(t.Context(), RangeSettingsAttrTypes, RangeSettings{
+		Enabled:        types.BoolValue(true),
+		ChunkSize:      types.Int64Value(5000000),
+		MaxParallelism: types.Int64Value(5),
+		BatchSize:      types.Int64Value(0),
+	})
+	assert.False(t, rangeDiags.HasError(), "unexpected diagnostics: %v", rangeDiags)
+
+	table := Table{
+		Name:          types.StringValue("offers"),
+		Schema:        types.StringValue("public"),
+		RangeSettings: rangeSettings,
+	}
+
+	apiTable, diags := table.ToAPIModel(t.Context())
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	assert.NotNil(t, apiTable.AdvancedSettings.RangeSettings)
+	assert.True(t, apiTable.AdvancedSettings.RangeSettings.Enabled)
+	assert.Equal(t, 5000000, apiTable.AdvancedSettings.RangeSettings.ChunkSize)
+	assert.Equal(t, 5, apiTable.AdvancedSettings.RangeSettings.MaxParallelism)
+	assert.Equal(t, 0, apiTable.AdvancedSettings.RangeSettings.BatchSize)
+}
+
+func TestTablesFromAPIModel_RangeSettings(t *testing.T) {
+	apiTables := []artieclient.Table{
+		{
+			UUID:   uuid.New(),
+			Name:   "offers",
+			Schema: "public",
+			AdvancedSettings: artieclient.AdvancedTableSettings{
+				RangeSettings: &artieclient.RangeSettings{
+					Enabled:        true,
+					ChunkSize:      5000000,
+					MaxParallelism: 5,
+					BatchSize:      0,
+				},
+			},
+		},
+	}
+
+	tables, diags := TablesFromAPIModel(t.Context(), apiTables)
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+
+	table := tables["public.offers"]
+	assert.False(t, table.RangeSettings.IsNull(), "range_settings should round-trip from API")
+
+	var rangeSettings RangeSettings
+	diags = table.RangeSettings.As(t.Context(), &rangeSettings, basetypes.ObjectAsOptions{})
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	assert.True(t, rangeSettings.Enabled.ValueBool())
+	assert.Equal(t, int64(5000000), rangeSettings.ChunkSize.ValueInt64())
+	assert.Equal(t, int64(5), rangeSettings.MaxParallelism.ValueInt64())
+	assert.Equal(t, int64(0), rangeSettings.BatchSize.ValueInt64())
 }
 
 func TestBoolPointerValueOrFalse(t *testing.T) {

--- a/internal/provider/tfmodels/pipeline_table_test.go
+++ b/internal/provider/tfmodels/pipeline_table_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
 
 	"terraform-provider-artie/internal/artieclient"
@@ -83,18 +82,13 @@ func TestTablesFromAPIModel_BoolSettingsRoundTripExplicitValues(t *testing.T) {
 }
 
 func TestTableToAPIModel_RangeSettings(t *testing.T) {
-	rangeSettings, rangeDiags := types.ObjectValueFrom(t.Context(), RangeSettingsAttrTypes, RangeSettings{
-		Enabled:        types.BoolValue(true),
-		ChunkSize:      types.Int64Value(5000000),
-		MaxParallelism: types.Int64Value(5),
-		BatchSize:      types.Int64Value(0),
-	})
-	assert.False(t, rangeDiags.HasError(), "unexpected diagnostics: %v", rangeDiags)
-
 	table := Table{
-		Name:          types.StringValue("offers"),
-		Schema:        types.StringValue("public"),
-		RangeSettings: rangeSettings,
+		Name:                types.StringValue("offers"),
+		Schema:              types.StringValue("public"),
+		RangeBackfill:       types.BoolValue(true),
+		RangeChunkSize:      types.Int64Value(5000000),
+		RangeMaxParallelism: types.Int64Value(5),
+		RangeBatchSize:      types.Int64Value(0),
 	}
 
 	apiTable, diags := table.ToAPIModel(t.Context())
@@ -104,6 +98,40 @@ func TestTableToAPIModel_RangeSettings(t *testing.T) {
 	assert.Equal(t, 5000000, apiTable.AdvancedSettings.RangeSettings.ChunkSize)
 	assert.Equal(t, 5, apiTable.AdvancedSettings.RangeSettings.MaxParallelism)
 	assert.Equal(t, 0, apiTable.AdvancedSettings.RangeSettings.BatchSize)
+}
+
+func TestTableToAPIModel_NullRangeBackfillOmitsRangeSettings(t *testing.T) {
+	table := Table{
+		Name:   types.StringValue("offers"),
+		Schema: types.StringValue("public"),
+	}
+
+	apiTable, diags := table.ToAPIModel(t.Context())
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	assert.Nil(t, apiTable.AdvancedSettings.RangeSettings)
+}
+
+func TestTablesFromAPIModel_NilRangeSettingsReadBackAsDisabled(t *testing.T) {
+	apiTables := []artieclient.Table{
+		{
+			UUID:   uuid.New(),
+			Name:   "offers",
+			Schema: "public",
+			AdvancedSettings: artieclient.AdvancedTableSettings{
+				RangeSettings: nil,
+			},
+		},
+	}
+
+	tables, diags := TablesFromAPIModel(t.Context(), apiTables)
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+
+	table := tables["public.offers"]
+	assert.False(t, table.RangeBackfill.IsNull(), "range_backfill should not read back as null")
+	assert.False(t, table.RangeBackfill.ValueBool())
+	assert.Equal(t, int64(0), table.RangeChunkSize.ValueInt64())
+	assert.Equal(t, int64(0), table.RangeMaxParallelism.ValueInt64())
+	assert.Equal(t, int64(0), table.RangeBatchSize.ValueInt64())
 }
 
 func TestTablesFromAPIModel_RangeSettings(t *testing.T) {
@@ -127,15 +155,10 @@ func TestTablesFromAPIModel_RangeSettings(t *testing.T) {
 	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
 
 	table := tables["public.offers"]
-	assert.False(t, table.RangeSettings.IsNull(), "range_settings should round-trip from API")
-
-	var rangeSettings RangeSettings
-	diags = table.RangeSettings.As(t.Context(), &rangeSettings, basetypes.ObjectAsOptions{})
-	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
-	assert.True(t, rangeSettings.Enabled.ValueBool())
-	assert.Equal(t, int64(5000000), rangeSettings.ChunkSize.ValueInt64())
-	assert.Equal(t, int64(5), rangeSettings.MaxParallelism.ValueInt64())
-	assert.Equal(t, int64(0), rangeSettings.BatchSize.ValueInt64())
+	assert.True(t, table.RangeBackfill.ValueBool())
+	assert.Equal(t, int64(5000000), table.RangeChunkSize.ValueInt64())
+	assert.Equal(t, int64(5), table.RangeMaxParallelism.ValueInt64())
+	assert.Equal(t, int64(0), table.RangeBatchSize.ValueInt64())
 }
 
 func TestBoolPointerValueOrFalse(t *testing.T) {


### PR DESCRIPTION
## Summary

Add Terraform support for table-level `range_settings` on `artie_pipeline` tables. The new nested block maps to Artie's `rangeSettings` API payload and includes `enabled`, `chunk_size`, `max_parallelism`, and `batch_size`.

## Context

Artie exposes range-based parallel backfill settings in the API/UI, but the provider could not currently manage or round-trip them. This meant users had to configure range backfills outside Terraform, creating drift and making imported pipelines incomplete.

This change keeps the provider schema aligned with existing table-level optimization settings: it adds the client model, Terraform model conversion in both directions, generated docs, and unit coverage for config-to-API and API-to-state behavior.

## Test plan

- [x] `go test ./internal/provider/tfmodels`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] `ASDF_TERRAFORM_VERSION=1.15.6 go generate ./...`

## Notes

`chunk_size` maps to the API field `chunksSize`, matching the existing Artie API shape while keeping the Terraform attribute name idiomatic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider schema and API mapping with validation and tests; only affects replication when users explicitly enable range backfill on a table.
> 
> **Overview**
> Adds **table-level range backfill** to `artie_pipeline` so Terraform can manage Artie's `rangeSettings` API (previously UI-only), matching the existing CTID backfill pattern.
> 
> New optional table fields: `range_backfill`, `range_chunk_size`, `range_max_parallelism`, and `range_batch_size` (0 = Artie default). The client maps `range_chunk_size` to the API's `chunksSize`. Plan validation requires the three numeric fields when `range_backfill` is true. API↔state conversion defaults missing range settings to disabled/zero to avoid drift. Docs and `tfmodels` tests cover round-trip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f5dd3e815fbcf6baedc39428230eca5b5cd45c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional range-based backfill settings on pipeline tables.
  * Users can now configure enablement and batching/concurrency values for table-level parallel processing.
* **Bug Fixes**
  * Table settings now round-trip correctly between configuration and the API, preserving range-related values when present.
* **Documentation**
  * Updated pipeline documentation with details and field requirements for the new table settings block.
* **Tests**
  * Added coverage for converting the new settings to and from the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->